### PR TITLE
select_region_scatterPlot feedback

### DIFF
--- a/roicat/ROInet.py
+++ b/roicat/ROInet.py
@@ -299,7 +299,7 @@ class ROInet_embedder(util.ROICaT_Module):
         if np.any([np.any(np.isinf(roi)) for roi in ROI_images]):
             warnings.warn('ROICaT WARNING: Infs detected. You should consider removing these before passing to the network.')
         ## Check if any images in any of the sessions are all zeros
-        if np.any([np.all(rois==0, axis=(1,2)) for rois in ROI_images]):
+        if np.any([np.any(np.all(rois==0, axis=(1,2))) for rois in ROI_images]):
             warnings.warn('ROICaT WARNING: Image(s) with all zeros detected. These can pass through the network, but may give weird results.')
         if nan_to_num:
             ROI_images = np.nan_to_num(ROI_images, nan=nan_to_num_val)

--- a/roicat/ROInet.py
+++ b/roicat/ROInet.py
@@ -302,7 +302,7 @@ class ROInet_embedder(util.ROICaT_Module):
         if np.any([np.any(np.all(rois==0, axis=(1,2))) for rois in ROI_images]):
             warnings.warn('ROICaT WARNING: Image(s) with all zeros detected. These can pass through the network, but may give weird results.')
         if nan_to_num:
-            ROI_images = np.nan_to_num(ROI_images, nan=nan_to_num_val)
+            ROI_images = [np.nan_to_num(rois, nan=nan_to_num_val) for rois in ROI_images]
 
         if numWorkers_dataloader == -1:
             numWorkers_dataloader = mp.cpu_count()

--- a/roicat/visualization.py
+++ b/roicat/visualization.py
@@ -338,10 +338,10 @@ def select_region_scatterPlot(
         idx_images_overlay (np.ndarray, optional):
             A vector of the data indices correspond to each images in images_overlay.
             Therefore, images_overlay must have the same number of images as idx_images_overlay. Defaults to None.
-        size_images_overlay (tuple, optional):
-            Size of each overlaid images. Defaults to None.
+        size_images_overlay (float, optional):
+            Size of each overlay images. Unit is relative to each axis. Defaults to None.
         figsize (tuple, optional):
-            Size of the figure. Defaults to (300,300).
+            Size of the figure. Unit in pixel. Defaults to (300,300).
     """
     import holoviews as hv
     import numpy as np


### PR DESCRIPTION
Tried scatterplot function. Fast and smooth like butter in colab environment. Marvelous.

Added a few changes and docstring.
Quick summary:

- 366 - 367 line is about _images_overlay_ and _idx_images_overlay_ variables. I added docstring and made a few correction following my understanding. I might have misunderstood what you originally intended. Please lmk if this is the case.
- 400 - 410 line touches RGB images. Here I pre-normalized R, G, B matrices before we stack them. Without this step output overlay image is all dark (too small values).