### PR TITLE
Add checks for warp_sparse_image for diagonal ROIs 

### DIFF
--- a/roicat/helpers.py
+++ b/roicat/helpers.py
@@ -3055,7 +3055,7 @@ def find_geometric_transformation(
             pass
         else:
             mask = (mask != 0).astype(np.uint8)
-    
+
     ## make gaussFiltSize odd
     gaussFiltSize = int(np.ceil(gaussFiltSize))
     gaussFiltSize = gaussFiltSize + (gaussFiltSize % 2 == 0)
@@ -3415,7 +3415,6 @@ def remap_sparse_images(
         rows, cols = im_coo.row, im_coo.col
         data = im_coo.data
 
-        # Account for 1d images by convolving image with tiny gaussian kernel to increase image width
         if safe:
             # can't use scipy.interpolate.griddata with 1d values
             is_horz = np.unique(rows).size == 1

--- a/roicat/helpers.py
+++ b/roicat/helpers.py
@@ -3417,25 +3417,40 @@ def remap_sparse_images(
 
         # Account for 1d images by convolving image with tiny gaussian kernel to increase image width
         if safe:
-            ## append if there are < 3 nonzero pixels
-            if (np.unique(rows).size == 1) or (np.unique(cols).size == 1) or (rows.size < 3):
+            # can't use scipy.interpolate.griddata with 1d values
+            is_horz = np.unique(rows).size == 1
+            is_vert = np.unique(cols).size == 1
+
+            # check for diagonal pixels (pretty sure this checks for all possibilities)
+            rdiff = np.diff(rows)
+            cdiff = np.diff(cols)
+            is_diag = np.all(rdiff[0] * cdiff == rdiff * cdiff[0]) and not(is_horz) and not(is_vert) # ruling out horz & vert for accuracy of name
+            
+            # best practice to just convolve instead of interpolating if too few pixels
+            is_smol = rows.size < 3 
+
+            if is_horz or is_vert or is_smol or is_diag:
+                # warp convolved sparse image directly without interpolation
                 return warp_sparse_image(im_sparse=conv2d(im_sparse, batching=False), remappingIdx=remappingIdx)
 
-        # Get values at the grid points
-        grid_values = scipy.interpolate.griddata(
-            points=(rows, cols), 
-            values=data, 
-            xi=remappingIdx[:,:,::-1], 
-            method=method, 
-            fill_value=fill_value,
-        )
+        try:
+            # Get values at the grid points
+            grid_values = scipy.interpolate.griddata(
+                points=(rows, cols), 
+                values=data, 
+                xi=remappingIdx[:,:,::-1], 
+                method=method, 
+                fill_value=fill_value,
+            )
+            # Create a new sparse image from the nonzero pixels
+            warped_sparse_image = scipy.sparse.csr_matrix(grid_values, dtype=dtype)
+            warped_sparse_image.eliminate_zeros()
+            return warped_sparse_image
+        
+        except:
+            # Fallback if we haven't accounted for all the possibilities that break scipy.interpolate.griddata()
+            return warp_sparse_image(im_sparse=conv2d(im_sparse, batching=False), remappingIdx=remappingIdx)
 
-        # Create a new sparse image from the nonzero pixels
-        warped_sparse_image = scipy.sparse.csr_matrix(grid_values, dtype=dtype)
-        warped_sparse_image.eliminate_zeros()
-
-        return warped_sparse_image
-    
     wsi_partial = partial(warp_sparse_image, remappingIdx=remappingIdx)
     ims_sparse_out = map_parallel(func=wsi_partial, args=(ims_sparse,), method='multithreading', workers=n_workers, prog_bar=verbose)
     return ims_sparse_out

--- a/roicat/util.py
+++ b/roicat/util.py
@@ -60,8 +60,9 @@ def get_default_parameters(
                 'random_seed': None,
             },
             'data_loading': {
-                'data_kind': 'suite2p',  ## Can be 'suite2p', 'roiextractors', or 'roicat'. See documentation and/or notebook on custom data loading for more details.
+                'data_kind': 'data_suite2p',  ## Can be 'data_suite2p', 'roiextractors', or 'roicat'. See documentation and/or notebook on custom data loading for more details.
                 'dir_outer': None,  ## directory where directories containing below 'pathSuffixTo...' are
+                'reMatch_in_path': None, ## additional string to filter paths (See documentation for roicat.helpers.find_paths())
                 'common': {
                     'um_per_pixel': 1.0,  ## Number of microns per pixel for the imaging dataset. Doesn't need to be exact. Used for resizing the ROIs. Check the images of the resized ROIs to tweak.
                     'centroid_method': 'centerOfMass', ## Can be 'centerOfMass' or 'median'.

--- a/run.py
+++ b/run.py
@@ -1,0 +1,80 @@
+from argparse import ArgumentParser
+from vrAnalysis import database
+from vrAnalysis import fileManagement
+from roicat.pipelines import pipeline_tracking
+from roicat.util import get_default_parameters
+
+WORKFLOWS = ['tracking']
+
+# === type definitions for argument parser ===
+def workflow(string):
+    """duck-type string to check if it is a valid ROICaT pipeline"""
+    try:
+        get_default_parameters(pipeline=string)
+    except:
+        raise ValueError(f"workflow {string} not supported")
+    else:
+        return string
+
+# === argument parser for run ===    
+def handle_arguments():
+    parser = ArgumentParser(description='Arguments for running an ROICaT pipeline.')
+    parser.add_argument('--mouse', type=str, required=True, help='the name of the mouse to process')
+    parser.add_argument('--workflow', type=workflow, required=True, help='which workflow to perform')
+    parser.add_argument('--no-database-update', default=False, action='store_true', help='if used, will not do a database update')
+    parser.add_argument('--nosave', action='store_true', default=False, help='whether to prevent saving')
+    return parser.parse_args()
+
+# === custom method for getting the appropriate dir_outer ===
+def define_dirs(args):
+    # first define save path and save name
+    dir_save = fileManagement.localDataPath() / args.mouse
+    name_save = lambda planeName: args.mouse + '.' + planeName
+    
+    # identify sessions for requested mouse (that match relevant criteria in database)
+    vrdb = database.vrDatabase('vrSessions')
+    ises = vrdb.iterSessions(imaging=True, mouseName=args.mouse, dontTrack=False)
+    assert len(ises)>0, f"no sessions found for mouse={args.mouse}"
+    session_paths = [ses.sessionPath() for ses in ises]
+
+    # for identified sessions, determine which planes are present
+    plane_in_ses = [set([pn.stem for pn in ses.suite2pPath().rglob('plane*')]) for ses in ises]
+    plane_names = set.union(*plane_in_ses)
+    assert all([planes == plane_names for planes in plane_in_ses]), "requested sessions have different sets of planes"
+    from natsort import natsorted
+    plane_names = natsorted(list(plane_names), key=lambda x: x.lower()) 
+
+    # inform the user what was found for this run
+    print('')
+    print(f"Running ROICaT:{args.workflow} on the following sessions:")
+    for idx, ises in enumerate(ises):
+        print('  ', idx, ises.sessionPrint())
+    
+    print('')
+    print(f"Using plane_names: {', '.join(plane_names)}")
+
+    # return to main
+    return session_paths, plane_names, dir_save, name_save
+
+# === main program that runs the requested pipeline ===
+if __name__ == "__main__":
+    args = handle_arguments()
+    params = get_default_parameters(args.workflow) # get default params
+    session_paths, plane_names, dir_save, name_save = define_dirs(args) # get session paths and planes to track
+    params['data_loading']['dir_outer'] = session_paths # load paths into the params dictionary
+        
+    if args.nosave: 
+        params['results_saving']['dir_save'] = None
+    else:
+        params['results_saving']['dir_save'] = dir_save # indicate where to save results
+
+    # Go through each plane and run the pipeline
+    for idx_plane, plane_name in enumerate(plane_names):
+        params['data_loading']['reMatch_in_path'] = plane_name # update planeName to filter paths by
+        params['results_saving']['prefix_name_save'] = name_save(plane_name) # define what the name is (combination of mouse name and plane name)
+        results, run_data, _ = pipeline_tracking(params) # do pipeline!
+
+
+
+
+

--- a/user.py
+++ b/user.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import argparse
+
+parser = argparse.ArgumentParser(description='perform user tasks')
+parser.add_argument('-t', '--task', type=str, default=None, help='which task to perform')
+parser.add_argument('--noupgrade', default=False, action='store_true')
+args = parser.parse_args()
+
+# This is just to store some locally used variables not relevant for any other user of roicat
+# Right now I suppose it's just to connect myself to other code I've written.
+def codePath():
+    return Path('C:/Users/andrew/Documents/GitHub/vrAnalysis')
+
+def remotePath():
+    return "https://github.com/landoskape/vrAnalysis"
+    
+def localDataPath():
+    return Path("C:/Users/andrew/Documents/localData")
+
+def analysisPath():
+    return localDataPath() / 'analysis'
+
+def updateVR(upgrade=True):
+    # convenience function that outputs the pip command for updating vrAnalysis
+    extra_args = "--force-reinstall --no-deps " if upgrade else ""
+    cmdPromptCommand = "pip install " + extra_args + f"git+{remotePath()}"
+    print(cmdPromptCommand)
+
+if args.task=='updateVR':
+    updateVR(upgrade=not(args.noupgrade))


### PR DESCRIPTION
The ``scipy.interpolate.griddata()`` method is used to fill in sparse ROI images. It doesn't work for 1d images. 

The code already includes a check for horizontal and vertical ROIs, but not diagonal ROIs. I added a check for diagonal ROIs to use convolution rather than scipy interpolation. 

Also, I added a fallback if ``griddata()`` fails to just use the convolution again, so that the pipeline doesn't break because one ROI can't be interpolated. 

Here's an example of an ROI that griddata() failed on that is 1-d (it's diagonal). I mean, I probably don't even want that ROI... but I want the pipeline to work :)

![image](https://github.com/RichieHakim/ROICaT/assets/17303166/ab1fb335-76fc-42f6-8a6e-c6fe49967c9c)
