### PR TITLE
allow custom data importer in tracking pipeline

### DIFF
--- a/roicat/pipelines.py
+++ b/roicat/pipelines.py
@@ -11,7 +11,7 @@ import numpy as np
 ## Import roicat submodules
 from . import data_importing, ROInet, helpers, util, visualization, tracking, classification
 
-def pipeline_tracking(params: dict):
+def pipeline_tracking(params: dict) -> tuple:
     """
     Pipeline for tracking ROIs across sessions.
     RH 2023
@@ -49,6 +49,7 @@ def pipeline_tracking(params: dict):
         deterministic=params['general']['random_seed'] is not None,
     )
 
+    
     if params['data_loading']['data_kind'] == 'suite2p':
         assert params['data_loading']['dir_outer'] is not None, f"params['data_loading']['dir_outer'] must be specified if params['data_loading']['data_kind'] is 'suite2p'."
         paths_allStat = helpers.find_paths(
@@ -93,7 +94,9 @@ def pipeline_tracking(params: dict):
 
         data.import_from_dict(
             dict_load=util.RichFile_ROICaT(path=paths_allDataObjs[0]).load(),
-        )
+            )
+    elif params['data_loading']['data_kind'] == 'custom':
+        data = params['data_loading']['data_custom']
     else:
         raise NotImplementedError(f"params['data_loading']['data_kind'] == '{params['data_loading']['data_kind']}' is not yet implemented.")
 

--- a/roicat/pipelines.py
+++ b/roicat/pipelines.py
@@ -100,6 +100,9 @@ def pipeline_tracking(params: dict) -> tuple:
     else:
         raise NotImplementedError(f"params['data_loading']['data_kind'] == '{params['data_loading']['data_kind']}' is not yet implemented.")
 
+    assert data.check_completeness(verbose=False)['tracking'], f"Data object is missing attributes necessary for tracking."
+    assert data.n_sessions > 1, f"Data object must have more than one session to track (n_sessions={data.n_sessions})."
+
 
     ## Alignment
     aligner = tracking.alignment.Aligner(

--- a/roicat/util.py
+++ b/roicat/util.py
@@ -80,6 +80,7 @@ def get_default_parameters(
                 'data_roicat': {
                     'filename_search': r'data_roicat.richfile',  ## Name stem of the single file (as a regex search string) in 'dir_outer' to look for. The files should be saved Data_roicat object.
                 },
+                'data_custom': None
             },
             'alignment': {
                 'initialization': {


### PR DESCRIPTION
Enables use of pipelines when supplying custom data importers.

@RichieHakim Still testing, but feedback on the approach welcome.