### PR TITLE
Fix missing local_corr dependency for tracking installs on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ tracking = [
     "fast-hdbscan==0.3.0",
     "kymatio==0.3.0",
     "kornia==0.8.2",
-    "romatch-roicat>=0.1.2.post1",
+    "romatch-roicat[fused-local-corr]>=0.1.2.post1; sys_platform == 'linux'",
+    "romatch-roicat>=0.1.2.post1; sys_platform != 'linux'",
     "roiextractors==0.8.0",
 ]
 all = [
@@ -96,7 +97,8 @@ all_latest = [
     "fast-hdbscan==0.3.0",
     "kymatio",
     "kornia",
-    "romatch-roicat",
+    "romatch-roicat[fused-local-corr]; sys_platform == 'linux'",
+    "romatch-roicat; sys_platform != 'linux'",
     "onnx2torch",
     "scikit-image",
     "selenium",


### PR DESCRIPTION
### Motivation
- The tracking pipeline imports `local_corr` from RoMa but the `romatch-roicat` package exposes its fused local-correlation implementation behind the `fused-local-corr` extra, so installs on Linux could miss that dependency and raise `ModuleNotFoundError` at runtime.
- The intent is to ensure Linux installations of `roicat[tracking]` (and the `all_latest` meta set) automatically pull in the `fused-local-corr` extra so the default tracking path works out-of-the-box.

### Description
- Updated `pyproject.toml` to require `romatch-roicat[fused-local-corr]>=0.1.2.post1` on Linux for the `tracking` optional dependency and to keep `romatch-roicat>=0.1.2.post1` for non-Linux platforms.
- Mirrored the same platform-specific split in the `all_latest` optional dependency group so latest-install paths are consistent.
- Made the change platform-conditional using `sys_platform == 'linux'` markers so non-Linux users keep the plain dependency.

### Testing
- Attempted `python -m pip install --dry-run -e '.[tracking]'`, which failed in this container due to the environment Python being 3.10 while the project requires `>=3.11`, so the dry-run could not complete (expected environment limitation).
- Parsed `pyproject.toml` with Python 3.11 using `tomllib` to validate the TOML and confirm the new dependency entries, which completed successfully.
- Queried PyPI for `romatch-roicat` and `fused-local-corr` to confirm `romatch-roicat` exposes the `fused-local-corr` extra and that `fused-local-corr` publishes Linux wheels, which returned expected metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef86ae89c883289a9b4bf0bdfadc69)