### PR TITLE
Algo install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ core = [
     "richfile>=0.6.2",
     "sparse_convolution>=0.4.0",
 ]
+
+
 classification = [
     "roicat[core]",
     "umap-learn==0.5.11",
@@ -105,6 +107,52 @@ all_latest = [
     "roiextractors==0.8.0",
     "sparse_convolution",
 ]
+
+core_algo = [
+    "natsort",
+    "numpy",
+    "optuna",
+    "Pillow",
+    "PyYAML",
+    "scikit-learn",
+    "scipy",
+    "sparse",
+    "tqdm",
+    "torch",
+    "torchvision",
+    "torchaudio",
+    "psutil",
+    "py-cpuinfo",
+    "skl2onnx",
+    "onnx>=1.17.0,<1.22.0",
+    "onnxruntime",
+    "richfile>=0.6.2",
+    "sparse_convolution>=0.4.0",
+]
+
+classification_algo = [
+    "roicat[core_algo]",
+    "umap-learn"
+]
+
+tracking_algo = [
+    "roicat[core_algo]",
+    "opencv-contrib-python-headless",
+    "fast-hdbscan",
+    "kymatio",
+    "kornia",
+    "romatch-roicat[fused-local-corr]>=0.1.2.post1; sys_platform == 'linux'",
+    "romatch-roicat>=0.1.2.post1; sys_platform != 'linux'",
+    "roiextractors==0.8.0",
+]
+
+all_algo = [
+    "roicat[core_algo,tracking_algo,classification_algo]",
+    "onnx2torch",
+    "scikit-image"
+]
+
+
 
 [project.scripts]
 roicat = "roicat.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,8 +141,7 @@ tracking_algo = [
     "fast-hdbscan",
     "kymatio",
     "kornia",
-    "romatch-roicat[fused-local-corr]>=0.1.2.post1; sys_platform == 'linux'",
-    "romatch-roicat>=0.1.2.post1; sys_platform != 'linux'",
+    "romatch-roicat[core_algo] @ git+https://github.com/apasarkar/RoMa.git@local_corr_check",
     "roiextractors==0.8.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ classification_algo = [
 
 tracking_algo = [
     "roicat[core_algo]",
-    "opencv-contrib-python-headless",
+    "opencv-contrib-python-headless==4.10.0.84", ## For cv2 DeepFlow
     "fast-hdbscan",
     "kymatio",
     "kornia",

--- a/roicat/__init__.py
+++ b/roicat/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 __version__ = '1.7.3'
 
 __all__ = [
@@ -13,6 +14,9 @@ __all__ = [
 ]
 
 for pkg in __all__:
-    exec('from . import ' + pkg)
+    try:
+        exec('from . import ' + pkg)
+    except ImportError as e:
+        warnings.warn(f"roicat.{pkg} unavailable. Install the relevant extra if you need to use it.")
 
 from .__main__ import run_pipeline

--- a/roicat/pipelines.py
+++ b/roicat/pipelines.py
@@ -1,6 +1,5 @@
 ## Import basic libraries
 from pathlib import Path
-import copy
 import tempfile
 from IPython.display import display
 import time
@@ -9,7 +8,7 @@ import time
 import numpy as np
 
 ## Import roicat submodules
-from . import data_importing, ROInet, helpers, util, visualization, tracking, classification
+from . import data_importing, ROInet, helpers, util, tracking
 
 def pipeline_tracking(params: dict, custom_data: data_importing.Data_roicat = None) -> tuple:
     """
@@ -450,7 +449,8 @@ def pipeline_tracking(params: dict, custom_data: data_importing.Data_roicat = No
         )
         (Path(dir_save).resolve() / 'visualization' / 'clustering').mkdir(parents=True, exist_ok=True)
         fig.savefig(str(Path(dir_save).resolve() / 'visualization' / 'clustering' / 'quality_metrics.png'))
-        
+
+        from . import visualization
         ### Save a gif of the ROIs
         FOV_clusters = visualization.compute_colored_FOV(
             spatialFootprints=[r.power(1.0) for r in results_all['ROIs']['ROIs_aligned']],  ## Spatial footprint sparse arrays


### PR DESCRIPTION
The goal of this PR is to allow for the leanest possible ROICaT install. These changes are introduced:
1. Extra install dependencies in pyproject.toml that allow users/other packages to install just the minimum algorithm-only backend code needed to do tracking/classification
2. Adjusts some importing (if some modules like visualization are missing, a warning is thrown, see the changes to __init__.py. 
3. Moves some imports in the pipeline code to be "lazily" imported. 

In order for this to be ready to merge, we will need to change back the romatch install in tracking_algo to once again be a published version. We will also likely need to merge + publish new romatch code on pypi, based on the following PR: https://github.com/RichieHakim/RoMa/pull/2

