### PR TITLE
ci: try Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           # "3.10",
           "3.11",
           "3.12",
-          # "3.13",  ## Many scientific deps lack py3.13 wheels (hdbscan, kymatio, onnx2torch)
+          "3.13",
         ]
         extra: [
           all,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A library for classifying and tracking ROIs."
 readme = "README.md"
 license = "GPL-3.0-only"
 license-files = ["LICENSE.md"]
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.11, <3.14"
 authors = [{name = "Richard Hakim"}]
 keywords = ["neuroscience", "neuroimaging", "machine learning", "deep learning"]
 


### PR DESCRIPTION
Adds 3.13 to the build matrix and lifts `requires-python` to `<3.14`. **This is a probe — merge only if it goes green.**

## Why this one first

The Python cap is the hardest obstacle to depending on ROICaT — harder than any version pin. A package that wants to support 3.13 cannot depend on ROICaT at all, and no optional-dependency group can work around it.

I checked every declared dependency's own metadata: **none of them caps the Python version.** The cap is ROICaT's own choice. That doesn't prove 3.13 works — wheel availability is a separate question from declared metadata — which is what this PR is for.

## The comment being removed

    # "3.13",  ## Many scientific deps lack py3.13 wheels (hdbscan, kymatio, onnx2torch)

`hdbscan` is no longer a dependency; `fast-hdbscan` replaced it and does ship 3.13. `kymatio` and `onnx2torch` are worth re-testing rather than assuming — both are pure Python as far as I can tell.

## What to expect

The matrix goes from 28 jobs to 42 (7 platforms × 3 Python versions × 2 extras). If the 3.13 jobs go red, the failures name exactly what still blocks it, and the cap goes back with an accurate comment instead of a stale one.