### PR TITLE
deps: separate runtime, unpinned and development extras

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,10 @@ jobs:
           # "3.13",  ## Many scientific deps lack py3.13 wheels (hdbscan, kymatio, onnx2torch)
         ]
         extra: [
-          all,
-          all_latest,
+          ## `dev` and `dev_latest` are `all` / `all_latest` plus the test
+          ## tooling, so the matrix still covers both dependency families.
+          dev,
+          dev_latest,
         ]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,23 +13,38 @@ requires-python = ">=3.11, <3.13"
 authors = [{name = "Richard Hakim"}]
 keywords = ["neuroscience", "neuroimaging", "machine learning", "deep learning"]
 
+## Two parallel families of extras, plus one for development.
+##
+##   core / classification / tracking / all
+##       Exact versions. What the docs, the notebooks and CI install, and what
+##       anyone reproducing published results should use.
+##
+##   core_latest / classification_latest / tracking_latest / all_latest
+##       Same packages, no version constraints. For packages that depend on
+##       ROICaT: a pinned dependency propagates its pins to everything
+##       downstream, which is usually not resolvable alongside the downstream
+##       package's own requirements.
+##
+##   dev
+##       Testing and notebook tooling. Not needed to use the library.
+##
+## tests/test_pyproject_extras.py asserts the two families name the same
+## packages, so they cannot drift apart.
 [project.optional-dependencies]
 core = [
-    "jupyter==1.1.1",
     "matplotlib==3.11.1",
     "mat73==0.65",
     "natsort==8.4.0",
     "numpy==2.4.6",
     "optuna==4.9.0",
+    "pandas==3.0.3",
     "Pillow==12.3.0",
-    "pytest==9.1.1",
     "PyYAML==6.0.3",
     "scikit-learn==1.9.0",
     "scipy==1.17.1",
     "seaborn==0.13.2",
     "sparse==0.19.0",
     "tqdm==4.70.0",
-    "xxhash==3.8.1",
     "torch==2.13.0",
     "torchvision==0.28.0",
     "psutil==7.2.2",
@@ -61,24 +76,22 @@ all = [
     "roicat[core,classification,tracking]",
     "onnx2torch==1.5.15",
     "scikit-image==0.26.0",
-    "selenium==4.46.0",
 ]
-all_latest = [
-    "jupyter",
+
+core_latest = [
     "matplotlib",
     "mat73",
     "natsort",
     "numpy",
     "optuna",
+    "pandas",
     "Pillow",
-    "pytest",
     "PyYAML",
     "scikit-learn",
     "scipy",
     "seaborn",
     "sparse",
     "tqdm",
-    "xxhash",
     "torch",
     "torchvision",
     "psutil",
@@ -87,21 +100,47 @@ all_latest = [
     "onnx",
     "onnxruntime",
     "richfile",
+    "sparse_convolution",
+]
+classification_latest = [
+    "roicat[core_latest]",
     "umap-learn",
     "bokeh",
     "holoviews[recommended]",
     "jupyter-bokeh",
+]
+tracking_latest = [
+    "roicat[core_latest]",
     "opencv-contrib-python-headless",
-    "fast-hdbscan==0.3.2",
+    "fast-hdbscan",
     "kymatio",
     "kornia",
     "romatch-roicat[fused-local-corr]; sys_platform == 'linux'",
     "romatch-roicat; sys_platform != 'linux'",
+    "roiextractors",
+]
+all_latest = [
+    "roicat[core_latest,classification_latest,tracking_latest]",
     "onnx2torch",
     "scikit-image",
+]
+
+## Running the test suite and the notebooks. `pytest` is here rather than in
+## `core` so that a package depending on ROICaT does not inherit a pinned test
+## runner it must then match.
+dev = [
+    "roicat[all]",
+    "jupyter==1.1.1",
+    "pytest==9.1.1",
+    "selenium==4.46.0",
+    "xxhash==3.8.1",
+]
+dev_latest = [
+    "roicat[all_latest]",
+    "jupyter",
+    "pytest",
     "selenium",
-    "roiextractors==0.9.0",
-    "sparse_convolution",
+    "xxhash",
 ]
 
 [project.scripts]

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -13,6 +13,7 @@ PACKAGES = [
     'onnx',
     'onnxruntime',
     'optuna',
+    'pandas',
     'psutil',
     'pytest',
     'scipy',
@@ -29,7 +30,7 @@ PACKAGES = [
     'holoviews',
     'jupyter_bokeh',
     'umap',
-    'hdbscan',
+    'fast_hdbscan',
     'kymatio',
 ]
 
@@ -45,7 +46,7 @@ def test_internal_package_tests():
 
     ## List of packages to test
     packages = [
-        'hdbscan',
+        'fast_hdbscan',
         'umap',
         'optuna',
         'cv2',

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -1,0 +1,152 @@
+"""
+Checks on the dependency extras declared in ``pyproject.toml``.
+
+There are two parallel families of extras: pinned (``core``, ``classification``,
+``tracking``, ``all``) and unpinned (the same names with a ``_latest`` suffix).
+The unpinned family exists so that other packages can depend on ROICaT without
+inheriting exact versions. Both families are hand-written, so they can drift
+apart -- and a package silently missing from the unpinned family only shows up
+as an ImportError in somebody else's install.
+
+These tests compare package *names* only. Version constraints are what the two
+families are supposed to differ on.
+"""
+
+from pathlib import Path
+import re
+import tomllib
+
+import pytest
+
+
+PATH_PYPROJECT = Path(__file__).resolve().parent.parent / 'pyproject.toml'
+
+## Pinned extra -> its unpinned counterpart.
+PAIRS_EXTRAS = {
+    'core': 'core_latest',
+    'classification': 'classification_latest',
+    'tracking': 'tracking_latest',
+    'all': 'all_latest',
+    'dev': 'dev_latest',
+}
+
+
+def _load_extras():
+    """
+    Returns:
+        (dict):
+            ``{extra_name: [requirement_string, ...]}`` from ``pyproject.toml``.
+    """
+    if not PATH_PYPROJECT.exists():
+        pytest.skip(f'pyproject.toml not found at {PATH_PYPROJECT}; not a source checkout.')
+    with open(PATH_PYPROJECT, 'rb') as f:
+        return tomllib.load(f)['project']['optional-dependencies']
+
+
+def _resolve(extras, name, _seen=None):
+    """
+    Expands one extra into the set of distribution names it pulls in, following
+    self-references like ``roicat[core]``.
+
+    Args:
+        extras (dict):
+            All optional-dependency groups.
+        name (str):
+            The group to expand.
+
+    Returns:
+        (set):
+            Lowercased distribution names, with ``-`` and ``_`` normalized, and
+            without version constraints, extras or environment markers.
+    """
+    _seen = set() if _seen is None else _seen
+    if name in _seen:
+        return set()  ## Self-referential extras would otherwise recurse forever.
+    _seen.add(name)
+
+    out = set()
+    for req in extras[name]:
+        ## Drop the environment marker; it distinguishes platforms, not packages.
+        req = req.split(';')[0].strip()
+        match = re.match(r'^([A-Za-z0-9_.\-]+)(?:\[([^\]]*)\])?', req)
+        dist, extras_requested = match.group(1), match.group(2)
+        if dist.lower() == 'roicat':
+            for sub in (extras_requested or '').split(','):
+                out |= _resolve(extras, sub.strip(), _seen)
+        else:
+            out.add(dist.lower().replace('_', '-'))
+    return out
+
+
+@pytest.mark.parametrize('extra_pinned, extra_latest', sorted(PAIRS_EXTRAS.items()))
+def test_pinned_and_latest_extras_name_the_same_packages(extra_pinned, extra_latest):
+    """
+    The unpinned family must cover exactly the same packages as the pinned one.
+    """
+    extras = _load_extras()
+    for name in (extra_pinned, extra_latest):
+        assert name in extras, f"pyproject.toml has no '{name}' extra."
+
+    pkgs_pinned = _resolve(extras, extra_pinned)
+    pkgs_latest = _resolve(extras, extra_latest)
+
+    assert pkgs_pinned == pkgs_latest, (
+        f"'{extra_pinned}' and '{extra_latest}' have drifted apart. "
+        f"Only in '{extra_pinned}': {sorted(pkgs_pinned - pkgs_latest)}. "
+        f"Only in '{extra_latest}': {sorted(pkgs_latest - pkgs_pinned)}."
+    )
+
+
+def test_latest_extras_are_unpinned():
+    """
+    A version constraint inside a ``_latest`` extra defeats its purpose: it is
+    the constraint, not the package, that a downstream package cannot satisfy.
+    """
+    extras = _load_extras()
+    constrained = {}
+    for name in PAIRS_EXTRAS.values():
+        for req in extras[name]:
+            body = req.split(';')[0].strip()
+            ## Strip the distribution name and any [extras] before looking for
+            ## a constraint, so 'holoviews[recommended]' does not read as one.
+            rest = re.sub(r'^[A-Za-z0-9_.\-]+(\[[^\]]*\])?', '', body).strip()
+            if rest and not body.lower().startswith('roicat['):
+                constrained.setdefault(name, []).append(req)
+    assert not constrained, f'Version constraints found in unpinned extras: {constrained}'
+
+
+def test_import_time_dependencies_are_declared():
+    """
+    Every package ``import roicat`` needs before any user code runs must be in
+    the ``all`` extra. ``pandas`` was missing for a long time and worked only
+    because seaborn happened to pull it in.
+    """
+    ## Third-party modules imported at module scope somewhere in the chain that
+    ## `import roicat` walks, mapped to the distribution that provides them.
+    MODULES_IMPORT_TIME = {
+        'matplotlib': 'matplotlib',
+        'numpy': 'numpy',
+        'onnx': 'onnx',
+        'onnxruntime': 'onnxruntime',
+        'optuna': 'optuna',
+        'pandas': 'pandas',
+        'PIL': 'pillow',
+        'scipy': 'scipy',
+        'sklearn': 'scikit-learn',
+        'sparse': 'sparse',
+        'torch': 'torch',
+        'torchvision': 'torchvision',
+        'tqdm': 'tqdm',
+        'yaml': 'pyyaml',
+        'cv2': 'opencv-contrib-python-headless',
+        'richfile': 'richfile',
+    }
+    extras = _load_extras()
+    declared = _resolve(extras, 'all')
+    missing = sorted({
+        dist for dist in MODULES_IMPORT_TIME.values()
+        if dist.replace('_', '-') not in declared
+    })
+    assert not missing, (
+        f'Imported at import time but not declared in the "all" extra: {missing}'
+    )


### PR DESCRIPTION
Three changes aimed at the same thing: letting another package depend on ROICaT without inheriting things it cannot satisfy.

## 1. Development tooling is no longer a runtime requirement

`core` contained `pytest==9.1.1`. Any package that depends on ROICaT and tests with pytest hits a hard version conflict on install. `jupyter`, `selenium` and `xxhash` were in the same position.

None of the four is imported by the library:

| package | only appears in |
|---|---|
| pytest | `tests/` |
| selenium | `tests/test_interactive.py` |
| xxhash | `conftest.py`, one fixture |
| jupyter | the notebooks and docs |

They move to a new `dev` extra (`roicat[all]` plus the four). CI now installs `dev` / `dev_latest` instead of `all` / `all_latest`, so the test tooling is still there.

## 2. The unpinned family is now granular

`all_latest` was the only unpinned option, and it is all-or-nothing — a package needing only tracking also pulled in jupyter, bokeh, holoviews and a browser automation library. It splits into `core_latest`, `classification_latest`, `tracking_latest`, `all_latest`, `dev_latest`, mirroring the pinned family and composing the same way (`roicat[core_latest]` etc.).

Two version constraints had survived inside `all_latest` — `fast-hdbscan==0.3.2` and `roiextractors==0.9.0`. Both got there through routine dependabot bumps rather than a known incompatibility (`git log -S` shows only "chore(deps-dev): bump ..."), so they are now unconstrained like everything else in that family. **Say the word if either was pinned deliberately and I will put it back.**

## 3. `pandas` is now declared

`roicat/visualization.py` imports pandas at module scope, and pandas appeared nowhere in `pyproject.toml`. `import roicat` works today only because seaborn depends on it. Any lean install that drops seaborn loses pandas.

## The test

`tests/test_pyproject_extras.py` (7 tests, ~0.5s) checks three things:

- the pinned and unpinned families name the same packages, following `roicat[...]` self-references — names only, since version constraints are what the families are meant to differ on;
- nothing in the unpinned family carries a version constraint;
- every package needed at *import time* is declared in `all` — the check that would have caught the pandas gap.

Each was verified against deliberate breakage: dropping a package from `core_latest` fails the first, adding a pin to `core_latest` fails the second, removing pandas fails the third.

## Testing

`test_unit.py`, `test_environment.py`, `test_packages.py`, `test_pyproject_extras.py`: 191 passed, 1 failed. The failure — `Test_image_alignment_checker_batching::test_self_comparison` — is **pre-existing on `dev`**, identical count and identical test. It passes when run alone and fails in a full run of `test_unit.py`, so something is order-dependent. Unrelated to this PR, but worth a look separately.

`tests/test_packages.py` also updated: its package list named `hdbscan`, which was replaced by `fast-hdbscan` some time ago, and did not include pandas.

## Note

#651 is stacked on this branch and should merge after it.