### PR TITLE
tracking: don't require RoMa's fused kernel where it cannot exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,12 @@ tracking = [
     "fast-hdbscan==0.3.2",
     "kymatio==0.3.0",
     "kornia==0.8.3",
-    "romatch-roicat[fused-local-corr]>=0.1.2.post1; sys_platform == 'linux'",
-    "romatch-roicat>=0.1.2.post1; sys_platform != 'linux'",
+    ## The 'fused-local-corr' extra publishes x86_64 Linux wheels only, with no
+    ## source distribution, so on ARM Linux the requirement cannot resolve at
+    ## all and the whole install fails. Ask for it only where it exists; RoMa
+    ## runs without it, more slowly.
+    "romatch-roicat[fused-local-corr]>=0.1.2.post1; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "romatch-roicat>=0.1.2.post1; sys_platform != 'linux' or platform_machine != 'x86_64'",
     "roiextractors==0.9.0",
 ]
 all = [
@@ -115,8 +119,8 @@ tracking_latest = [
     "fast-hdbscan",
     "kymatio",
     "kornia",
-    "romatch-roicat[fused-local-corr]; sys_platform == 'linux'",
-    "romatch-roicat; sys_platform != 'linux'",
+    "romatch-roicat[fused-local-corr]; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "romatch-roicat; sys_platform != 'linux' or platform_machine != 'x86_64'",
     "roiextractors",
 ]
 all_latest = [

--- a/roicat/tracking/alignment.py
+++ b/roicat/tracking/alignment.py
@@ -1595,7 +1595,7 @@ class ImageRegistrationMethod:
 
 
 @functools.lru_cache(maxsize=1)
-def _fused_local_corr_available(verbose: bool = True) -> bool:
+def _reason_fused_local_corr_unavailable() -> Optional[str]:
     """
     Checks whether RoMa's fused local-correlation kernel can actually be loaded.
 
@@ -1608,27 +1608,19 @@ def _fused_local_corr_available(verbose: bool = True) -> bool:
     assumes the kernel is present and the ImportError surfaces several frames
     down inside the matcher, at match time rather than at construction.
 
-    Args:
-        verbose (bool):
-            Whether to warn when the kernel is unavailable.
-            (Default is ``True``)
+    Cached, and deliberately takes no arguments: the answer is a property of the
+    installation, and the caller decides whether to say anything about it.
 
     Returns:
-        (bool):
-            ``True`` if ``import local_corr`` succeeds.
+        (Optional[str]):
+            ``None`` if ``import local_corr`` succeeds, otherwise the reason it
+            did not.
     """
     try:
         import local_corr  ## noqa: F401
-        return True
+        return None
     except ImportError as e:
-        if verbose:
-            warnings.warn(
-                f"RoMa's fused local correlation kernel is unavailable, so the slower "
-                f"pure-PyTorch path will be used. Reason: {e}. The kernel is provided by "
-                f"the 'fused-local-corr' package and needs x86_64 Linux with the CUDA "
-                f"runtime libraries present."
-            )
-        return False
+        return str(e)
 
 
 class RoMa(ImageRegistrationMethod):
@@ -1767,7 +1759,15 @@ class RoMa(ImageRegistrationMethod):
 
         ## Decided here rather than left to romatch, which only checks the
         ## platform and would let a Linux machine without the kernel through.
-        use_custom_corr = _fused_local_corr_available(verbose=verbose)
+        reason_no_corr = _reason_fused_local_corr_unavailable()
+        use_custom_corr = reason_no_corr is None
+        if (reason_no_corr is not None) and verbose:
+            warnings.warn(
+                f"RoMa's fused local correlation kernel is unavailable, so the slower "
+                f"pure-PyTorch path will be used. Reason: {reason_no_corr}. The kernel is "
+                f"provided by the 'fused-local-corr' package and needs x86_64 Linux with "
+                f"the CUDA runtime libraries present."
+            )
 
         if model_type == 'outdoor':
             self.model = roma_outdoor(device=device, weights=weights, dinov2_weights=weights_dinov2, use_custom_corr=use_custom_corr)

--- a/roicat/tracking/alignment.py
+++ b/roicat/tracking/alignment.py
@@ -1594,6 +1594,43 @@ class ImageRegistrationMethod:
         raise NotImplementedError(f"Method _forward_rigid not implemented for {self.__class__.__name__}.")
 
 
+@functools.lru_cache(maxsize=1)
+def _fused_local_corr_available(verbose: bool = True) -> bool:
+    """
+    Checks whether RoMa's fused local-correlation kernel can actually be loaded.
+
+    The kernel lives in a separate package, ``fused-local-corr``, which romatch
+    declares as an optional extra. Two things can leave it unusable on a machine
+    that romatch believes is fine: it publishes x86_64 Linux wheels only, and
+    even where it installs it is a compiled extension linked against the CUDA
+    runtime, so it fails to load wherever the CUDA libraries are absent.
+    romatch's own check looks at the platform alone, so on any Linux box it
+    assumes the kernel is present and the ImportError surfaces several frames
+    down inside the matcher, at match time rather than at construction.
+
+    Args:
+        verbose (bool):
+            Whether to warn when the kernel is unavailable.
+            (Default is ``True``)
+
+    Returns:
+        (bool):
+            ``True`` if ``import local_corr`` succeeds.
+    """
+    try:
+        import local_corr  ## noqa: F401
+        return True
+    except ImportError as e:
+        if verbose:
+            warnings.warn(
+                f"RoMa's fused local correlation kernel is unavailable, so the slower "
+                f"pure-PyTorch path will be used. Reason: {e}. The kernel is provided by "
+                f"the 'fused-local-corr' package and needs x86_64 Linux with the CUDA "
+                f"runtime libraries present."
+            )
+        return False
+
+
 class RoMa(ImageRegistrationMethod):
     """
     RoMa-based image registration method.
@@ -1728,10 +1765,14 @@ class RoMa(ImageRegistrationMethod):
             fallback_weight_urls=fallback_weight_urls["dinov2"],
         )
 
+        ## Decided here rather than left to romatch, which only checks the
+        ## platform and would let a Linux machine without the kernel through.
+        use_custom_corr = _fused_local_corr_available(verbose=verbose)
+
         if model_type == 'outdoor':
-            self.model = roma_outdoor(device=device, weights=weights, dinov2_weights=weights_dinov2)
+            self.model = roma_outdoor(device=device, weights=weights, dinov2_weights=weights_dinov2, use_custom_corr=use_custom_corr)
         elif model_type == 'indoor':
-            self.model = roma_indoor(device=device, weights=weights, dinov2_weights=weights_dinov2)
+            self.model = roma_indoor(device=device, weights=weights, dinov2_weights=weights_dinov2, use_custom_corr=use_custom_corr)
     
     def _match(
         self,

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -120,6 +120,12 @@ def test_import_time_dependencies_are_declared():
     Every package ``import roicat`` needs before any user code runs must be in
     the ``all`` extra. ``pandas`` was missing for a long time and worked only
     because seaborn happened to pull it in.
+
+    The list below describes the *current* import structure, in which
+    ``roicat/__init__.py`` eagerly imports every submodule. If those imports are
+    ever made lazy, fewer packages will be needed at import time and entries
+    here should be removed -- a failure after such a change means the list is
+    stale, not that the change was wrong.
     """
     ## Third-party modules imported at module scope somewhere in the chain that
     ## `import roicat` walks, mapped to the distribution that provides them.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2820,3 +2820,48 @@ class Test_Preprocessor_ROI_images:
         preprocessor = Preprocessor_ROI_images(verbose=False)
         with pytest.raises(ValueError, match='3-D'):
             preprocessor.transform_images(ROI_images=np.zeros((36, 36), dtype=np.float32))
+
+
+class Test_reason_fused_local_corr_unavailable:
+    """
+    The helper that decides whether RoMa is given its fused correlation kernel.
+
+    Every test clears the cache on both sides. The helper is ``lru_cache``d, so
+    without that the answer depends on which test ran first, and a cached answer
+    derived from a patched ``sys.modules`` would leak into the rest of the run.
+    """
+
+    @staticmethod
+    def _fn():
+        from roicat.tracking.alignment import _reason_fused_local_corr_unavailable
+        return _reason_fused_local_corr_unavailable
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        self._fn().cache_clear()
+        yield
+        self._fn().cache_clear()
+
+    def test_returns_none_when_kernel_imports(self, monkeypatch):
+        import sys, types
+        monkeypatch.setitem(sys.modules, 'local_corr', types.ModuleType('local_corr'))
+        assert self._fn()() is None
+
+    def test_returns_reason_when_kernel_missing(self, monkeypatch):
+        import sys
+        ## A None entry in sys.modules makes `import local_corr` raise ImportError,
+        ## which is the same failure a machine without the package produces.
+        monkeypatch.setitem(sys.modules, 'local_corr', None)
+        reason = self._fn()()
+        assert isinstance(reason, str) and reason
+
+    def test_answer_is_cached(self, monkeypatch):
+        import sys, types
+        monkeypatch.setitem(sys.modules, 'local_corr', types.ModuleType('local_corr'))
+        assert self._fn()() is None
+        ## The installation cannot change mid-process, so the second call must
+        ## not re-probe even though the module is now unimportable.
+        monkeypatch.setitem(sys.modules, 'local_corr', None)
+        assert self._fn()() is None
+        self._fn().cache_clear()
+        assert isinstance(self._fn()(), str)


### PR DESCRIPTION
> **Stacked on #650** — base branch is `extras-restructure`, since both touch the same block of `pyproject.toml`. Review this one after that merges, or retarget it to `dev` and I will rebase.

Two halves of the same problem, and the second is the one that matters more.

## Install time: ARM Linux cannot install tracking at all

`tracking` asks for `romatch-roicat[fused-local-corr]` on *every* Linux machine. That package publishes x86_64 manylinux wheels only — **no source distribution, no ARM wheels, in any released version** (checked all 11 releases on PyPI). On ARM Linux pip finds nothing to install and `pip install roicat[tracking]` fails outright.

The markers now ask for the accelerated build only on x86_64 Linux and plain romatch everywhere else. Verified the pair is mutually exclusive and exhaustive:

| platform | machine | with extra | plain |
|---|---|---|---|
| linux | x86_64 | ✓ | |
| linux | aarch64 | | ✓ |
| darwin | arm64 | | ✓ |
| win32 | AMD64 | | ✓ |

## Run time: the same kernel is already failing silently on x86_64

Not asking for it at install time is only half the fix, because romatch decides whether to *use* it from `sys.platform` alone. On any Linux machine it assumes the kernel is there, so:

- a Linux user who has no `fused-local-corr` — including anyone who installs after this PR on ARM — gets an `ImportError` several frames inside the matcher, at match time;
- and so does a **x86_64** user with the kernel installed but no CUDA runtime libraries. It is a compiled extension linked against CUDA. On the machine I developed this on, with `fused-local-corr` 0.2.4 installed, `import local_corr` raises `ImportError: libcudart.so.12: cannot open shared object file`.

That second case is live today on any CPU-only Linux box.

So `RoMa.__init__` now checks whether `local_corr` actually imports and passes `use_custom_corr` to romatch accordingly, warning with the reason. romatch falls back to a pure-PyTorch local correlation — slower, same result. The check is `lru_cache`d on no arguments, and the warning is emitted by the caller.

**This PR does not depend on any change to romatch** — it works against the currently published version, and `roma_outdoor` / `roma_indoor` have accepted `use_custom_corr` since 0.1.2.post1. Fixing the same check upstream is a separate question.

## No CI here

This PR's base is `extras-restructure`, and `build.yml` only triggers on pull requests into `main` or `dev` — so the build matrix does not run on it. It will run once #650 merges and this retargets to `dev`, or immediately if you retarget it now and I rebase.

## Testing

- `_fused_local_corr_available()` returns `False` here with the libcudart reason in the warning, and caches.
- Marker table above, evaluated with `packaging.markers`.
- The extras tests still pass.

**Not covered:** no test in the suite exercises the RoMa registration path — `test_integration.py` uses `DISK_LightGlue` and `DeepFlow` — and I did not download the RoMa weights to run one by hand. The change is a keyword argument that already exists and already defaults to `True`, and `False` is exactly what romatch passes itself on non-Linux, so the risk is small. But it is untested end to end and you should know that.

## Aside

`tiny_roma_v1_outdoor` is imported in `RoMa.__init__` and never used, and `model_type` values other than `'outdoor'`/`'indoor'` fall through without setting `self.model` and without an error. Pre-existing; not touched here.