### PR TITLE
Python 3.13: make the docs match, and keep them matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ installation process, please make a [github
 issue](https://github.com/RichieHakim/ROICaT/issues) with the error.
 
 ### 0. Requirements
-- **Python 3.11 or 3.12** (3.13 is not yet supported).
+- **Python 3.11, 3.12, or 3.13**.
 - [Anaconda](https://www.anaconda.com/distribution/) or
   [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
 - The below commands should be run in the terminal (Mac/Linux) or Anaconda
@@ -214,7 +214,7 @@ sudo docker run -it -p 7860:7860 --platform=linux/amd64 --shm-size=10g registry.
 - [ ] Spruce up training code
 - [x] Switch off pickling optuna save file
 - [ ] Try training on cellpose datasets
-- [ ] Python 3.13
+- [x] Python 3.13
 #### other:
 - [ ] Write the paper
 - [ ] Make tweet about it

--- a/docs/helpers/create_env.txt
+++ b/docs/helpers/create_env.txt
@@ -1,3 +1,3 @@
-conda create -n roicat python=3.11
+conda create -n roicat python=3.12
 conda activate roicat
 pip install --upgrade pip

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -156,3 +156,82 @@ def test_import_time_dependencies_are_declared():
     assert not missing, (
         f'Imported at import time but not declared in the "all" extra: {missing}'
     )
+
+
+######################################################################################################################################
+######################################################## PYTHON VERSIONS #############################################################
+######################################################################################################################################
+
+PATH_BUILD_YML = Path(__file__).resolve().parent.parent / '.github' / 'workflows' / 'build.yml'
+
+## Candidate minor versions to ask `requires-python` about. Wide enough that the
+## range does not need revisiting when Python moves on.
+VERSIONS_CANDIDATE = [f'3.{n}' for n in range(8, 30)]
+
+
+def _versions_supported():
+    """
+    Returns:
+        (set): the ``3.x`` strings that ``requires-python`` admits.
+    """
+    from packaging.specifiers import SpecifierSet
+
+    if not PATH_PYPROJECT.exists():
+        pytest.skip(f'pyproject.toml not found at {PATH_PYPROJECT}; not a source checkout.')
+    with open(PATH_PYPROJECT, 'rb') as f:
+        spec = SpecifierSet(tomllib.load(f)['project']['requires-python'])
+    return {v for v in VERSIONS_CANDIDATE if spec.contains(v)}
+
+
+def _versions_tested():
+    """
+    Returns:
+        (set): the ``3.x`` strings in the CI build matrix. Commented-out entries
+        are not included -- YAML drops them, which is the intended reading.
+    """
+    import yaml
+
+    if not PATH_BUILD_YML.exists():
+        pytest.skip(f'build.yml not found at {PATH_BUILD_YML}; not a source checkout.')
+    with open(PATH_BUILD_YML, 'r') as f:
+        workflow = yaml.safe_load(f)
+    return {str(v) for v in workflow['jobs']['build']['strategy']['matrix']['python-version']}
+
+
+def test_ci_tests_every_supported_python():
+    """
+    The versions CI runs and the versions ``requires-python`` admits must match.
+
+    Drift in either direction is a problem. A version admitted but not tested is
+    a support claim with nothing behind it; a version tested but not admitted
+    means the install step in that job cannot have run at all, so the job proves
+    nothing while still reporting green. 3.13 spent months commented out of the
+    matrix while the README said it was unsupported and nothing checked either.
+    """
+    supported, tested = _versions_supported(), _versions_tested()
+    assert supported == tested, (
+        f"requires-python admits {sorted(supported)} but CI runs {sorted(tested)}. "
+        f"Only in requires-python: {sorted(supported - tested)}. "
+        f"Only in CI: {sorted(tested - supported)}."
+    )
+
+
+def test_readme_states_the_supported_pythons():
+    """
+    The README's Requirements line is what users actually read, so it must name
+    every supported version and nothing else.
+    """
+    path_readme = Path(__file__).resolve().parent.parent / 'README.md'
+    if not path_readme.exists():
+        pytest.skip(f'README.md not found at {path_readme}; not a source checkout.')
+    line = next(
+        (l for l in path_readme.read_text(encoding='utf-8').splitlines() if '**Python' in l),
+        None,
+    )
+    assert line is not None, "No '**Python ...**' requirements line found in README.md."
+
+    named = set(re.findall(r'3\.\d+', line))
+    assert named == _versions_supported(), (
+        f"README requirements line names {sorted(named)}: {line.strip()!r}, "
+        f"but requires-python admits {sorted(_versions_supported())}."
+    )


### PR DESCRIPTION
#649 lifted `requires-python` to `<3.14` and turned on 3.13 in CI. The user-facing side never followed.

## Changes

- `README.md` — Requirements said *"Python 3.11 or 3.12 (3.13 is not yet supported)"*. Now 3.11, 3.12 or 3.13.
- `README.md` — roadmap item `Python 3.13` checked off.
- `docs/helpers/create_env.txt` — `python=3.11` to `python=3.12`, matching the README's own instructions. These already disagreed before this PR.
- `tests/test_pyproject_extras.py` — two tests so this cannot drift again.

## The tests

`test_ci_tests_every_supported_python` compares the CI matrix to `requires-python` in **both** directions. A version admitted but not tested is a support claim with nothing behind it. A version tested but not admitted is worse: `pip install -e .` refuses, so the job proves nothing while still reporting green.

`test_readme_states_the_supported_pythons` checks the README Requirements line names exactly the supported set.

Both were verified to fail when the versions are put back out of step, not just to pass as written.

## Deliberately unchanged

- `docs/.readthedocs.yaml` pins the docs build to Python 3.11. That is the interpreter Read the Docs builds with, not a statement about what ROICaT supports, and I cannot test an RTD build from here.
- `.github/workflows/pypi_release.yml` builds with 3.11. ROICaT is a pure-Python wheel, so the build interpreter does not affect the artifact.
- `README.md` still recommends `conda create -n roicat python=3.12`. 3.13 is tested and supported, but 3.12 is the safer default for a new user. One-word change if you would rather lead with 3.13.

## Not covered

Notebook `kernelspec` metadata still records whichever interpreter last ran each notebook (3.11.9, 3.12.9). That is a recording of the past, not a claim about support, so I left it.