### PR TITLE
Release 1.7.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,10 @@ jobs:
           # "3.13",  ## Many scientific deps lack py3.13 wheels (hdbscan, kymatio, onnx2torch)
         ]
         extra: [
-          all,
-          all_latest,
+          ## `dev` and `dev_latest` are `all` / `all_latest` plus the test
+          ## tooling, so the matrix still covers both dependency families.
+          dev,
+          dev_latest,
         ]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           # "3.10",
           "3.11",
           "3.12",
-          # "3.13",  ## Many scientific deps lack py3.13 wheels (hdbscan, kymatio, onnx2torch)
+          "3.13",
         ]
         extra: [
           all,

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ installation process, please make a [github
 issue](https://github.com/RichieHakim/ROICaT/issues) with the error.
 
 ### 0. Requirements
-- **Python 3.11 or 3.12** (3.13 is not yet supported).
+- **Python 3.11, 3.12, or 3.13**.
 - [Anaconda](https://www.anaconda.com/distribution/) or
   [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
 - The below commands should be run in the terminal (Mac/Linux) or Anaconda
@@ -214,7 +214,7 @@ sudo docker run -it -p 7860:7860 --platform=linux/amd64 --shm-size=10g registry.
 - [ ] Spruce up training code
 - [x] Switch off pickling optuna save file
 - [ ] Try training on cellpose datasets
-- [ ] Python 3.13
+- [x] Python 3.13
 #### other:
 - [ ] Write the paper
 - [ ] Make tweet about it

--- a/docs/helpers/create_env.txt
+++ b/docs/helpers/create_env.txt
@@ -1,3 +1,3 @@
-conda create -n roicat python=3.11
+conda create -n roicat python=3.12
 conda activate roicat
 pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,12 @@ tracking = [
     "fast-hdbscan==0.3.2",
     "kymatio==0.3.0",
     "kornia==0.8.3",
-    "romatch-roicat[fused-local-corr]>=0.1.2.post1; sys_platform == 'linux'",
-    "romatch-roicat>=0.1.2.post1; sys_platform != 'linux'",
+    ## The 'fused-local-corr' extra publishes x86_64 Linux wheels only, with no
+    ## source distribution, so on ARM Linux the requirement cannot resolve at
+    ## all and the whole install fails. Ask for it only where it exists; RoMa
+    ## runs without it, more slowly.
+    "romatch-roicat[fused-local-corr]>=0.1.2.post1; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "romatch-roicat>=0.1.2.post1; sys_platform != 'linux' or platform_machine != 'x86_64'",
     "roiextractors==0.9.0",
 ]
 all = [
@@ -115,8 +119,8 @@ tracking_latest = [
     "fast-hdbscan",
     "kymatio",
     "kornia",
-    "romatch-roicat[fused-local-corr]; sys_platform == 'linux'",
-    "romatch-roicat; sys_platform != 'linux'",
+    "romatch-roicat[fused-local-corr]; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "romatch-roicat; sys_platform != 'linux' or platform_machine != 'x86_64'",
     "roiextractors",
 ]
 all_latest = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A library for classifying and tracking ROIs."
 readme = "README.md"
 license = "GPL-3.0-only"
 license-files = ["LICENSE.md"]
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.11, <3.14"
 authors = [{name = "Richard Hakim"}]
 keywords = ["neuroscience", "neuroimaging", "machine learning", "deep learning"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,23 +13,38 @@ requires-python = ">=3.11, <3.13"
 authors = [{name = "Richard Hakim"}]
 keywords = ["neuroscience", "neuroimaging", "machine learning", "deep learning"]
 
+## Two parallel families of extras, plus one for development.
+##
+##   core / classification / tracking / all
+##       Exact versions. What the docs, the notebooks and CI install, and what
+##       anyone reproducing published results should use.
+##
+##   core_latest / classification_latest / tracking_latest / all_latest
+##       Same packages, no version constraints. For packages that depend on
+##       ROICaT: a pinned dependency propagates its pins to everything
+##       downstream, which is usually not resolvable alongside the downstream
+##       package's own requirements.
+##
+##   dev
+##       Testing and notebook tooling. Not needed to use the library.
+##
+## tests/test_pyproject_extras.py asserts the two families name the same
+## packages, so they cannot drift apart.
 [project.optional-dependencies]
 core = [
-    "jupyter==1.1.1",
     "matplotlib==3.11.1",
     "mat73==0.65",
     "natsort==8.4.0",
     "numpy==2.4.6",
     "optuna==4.9.0",
+    "pandas==3.0.3",
     "Pillow==12.3.0",
-    "pytest==9.1.1",
     "PyYAML==6.0.3",
     "scikit-learn==1.9.0",
     "scipy==1.17.1",
     "seaborn==0.13.2",
     "sparse==0.19.0",
     "tqdm==4.70.0",
-    "xxhash==3.8.1",
     "torch==2.13.0",
     "torchvision==0.28.0",
     "psutil==7.2.2",
@@ -61,24 +76,22 @@ all = [
     "roicat[core,classification,tracking]",
     "onnx2torch==1.5.15",
     "scikit-image==0.26.0",
-    "selenium==4.46.0",
 ]
-all_latest = [
-    "jupyter",
+
+core_latest = [
     "matplotlib",
     "mat73",
     "natsort",
     "numpy",
     "optuna",
+    "pandas",
     "Pillow",
-    "pytest",
     "PyYAML",
     "scikit-learn",
     "scipy",
     "seaborn",
     "sparse",
     "tqdm",
-    "xxhash",
     "torch",
     "torchvision",
     "psutil",
@@ -87,21 +100,47 @@ all_latest = [
     "onnx",
     "onnxruntime",
     "richfile",
+    "sparse_convolution",
+]
+classification_latest = [
+    "roicat[core_latest]",
     "umap-learn",
     "bokeh",
     "holoviews[recommended]",
     "jupyter-bokeh",
+]
+tracking_latest = [
+    "roicat[core_latest]",
     "opencv-contrib-python-headless",
-    "fast-hdbscan==0.3.2",
+    "fast-hdbscan",
     "kymatio",
     "kornia",
     "romatch-roicat[fused-local-corr]; sys_platform == 'linux'",
     "romatch-roicat; sys_platform != 'linux'",
+    "roiextractors",
+]
+all_latest = [
+    "roicat[core_latest,classification_latest,tracking_latest]",
     "onnx2torch",
     "scikit-image",
+]
+
+## Running the test suite and the notebooks. `pytest` is here rather than in
+## `core` so that a package depending on ROICaT does not inherit a pinned test
+## runner it must then match.
+dev = [
+    "roicat[all]",
+    "jupyter==1.1.1",
+    "pytest==9.1.1",
+    "selenium==4.46.0",
+    "xxhash==3.8.1",
+]
+dev_latest = [
+    "roicat[all_latest]",
+    "jupyter",
+    "pytest",
     "selenium",
-    "roiextractors==0.9.0",
-    "sparse_convolution",
+    "xxhash",
 ]
 
 [project.scripts]

--- a/roicat/__init__.py
+++ b/roicat/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.7.6'
+__version__ = '1.7.7'
 
 __all__ = [
     'classification',

--- a/roicat/tracking/alignment.py
+++ b/roicat/tracking/alignment.py
@@ -1595,7 +1595,7 @@ class ImageRegistrationMethod:
 
 
 @functools.lru_cache(maxsize=1)
-def _fused_local_corr_available(verbose: bool = True) -> bool:
+def _reason_fused_local_corr_unavailable() -> Optional[str]:
     """
     Checks whether RoMa's fused local-correlation kernel can actually be loaded.
 
@@ -1608,27 +1608,19 @@ def _fused_local_corr_available(verbose: bool = True) -> bool:
     assumes the kernel is present and the ImportError surfaces several frames
     down inside the matcher, at match time rather than at construction.
 
-    Args:
-        verbose (bool):
-            Whether to warn when the kernel is unavailable.
-            (Default is ``True``)
+    Cached, and deliberately takes no arguments: the answer is a property of the
+    installation, and the caller decides whether to say anything about it.
 
     Returns:
-        (bool):
-            ``True`` if ``import local_corr`` succeeds.
+        (Optional[str]):
+            ``None`` if ``import local_corr`` succeeds, otherwise the reason it
+            did not.
     """
     try:
         import local_corr  ## noqa: F401
-        return True
+        return None
     except ImportError as e:
-        if verbose:
-            warnings.warn(
-                f"RoMa's fused local correlation kernel is unavailable, so the slower "
-                f"pure-PyTorch path will be used. Reason: {e}. The kernel is provided by "
-                f"the 'fused-local-corr' package and needs x86_64 Linux with the CUDA "
-                f"runtime libraries present."
-            )
-        return False
+        return str(e)
 
 
 class RoMa(ImageRegistrationMethod):
@@ -1767,7 +1759,15 @@ class RoMa(ImageRegistrationMethod):
 
         ## Decided here rather than left to romatch, which only checks the
         ## platform and would let a Linux machine without the kernel through.
-        use_custom_corr = _fused_local_corr_available(verbose=verbose)
+        reason_no_corr = _reason_fused_local_corr_unavailable()
+        use_custom_corr = reason_no_corr is None
+        if (reason_no_corr is not None) and verbose:
+            warnings.warn(
+                f"RoMa's fused local correlation kernel is unavailable, so the slower "
+                f"pure-PyTorch path will be used. Reason: {reason_no_corr}. The kernel is "
+                f"provided by the 'fused-local-corr' package and needs x86_64 Linux with "
+                f"the CUDA runtime libraries present."
+            )
 
         if model_type == 'outdoor':
             self.model = roma_outdoor(device=device, weights=weights, dinov2_weights=weights_dinov2, use_custom_corr=use_custom_corr)

--- a/roicat/tracking/alignment.py
+++ b/roicat/tracking/alignment.py
@@ -1594,6 +1594,43 @@ class ImageRegistrationMethod:
         raise NotImplementedError(f"Method _forward_rigid not implemented for {self.__class__.__name__}.")
 
 
+@functools.lru_cache(maxsize=1)
+def _fused_local_corr_available(verbose: bool = True) -> bool:
+    """
+    Checks whether RoMa's fused local-correlation kernel can actually be loaded.
+
+    The kernel lives in a separate package, ``fused-local-corr``, which romatch
+    declares as an optional extra. Two things can leave it unusable on a machine
+    that romatch believes is fine: it publishes x86_64 Linux wheels only, and
+    even where it installs it is a compiled extension linked against the CUDA
+    runtime, so it fails to load wherever the CUDA libraries are absent.
+    romatch's own check looks at the platform alone, so on any Linux box it
+    assumes the kernel is present and the ImportError surfaces several frames
+    down inside the matcher, at match time rather than at construction.
+
+    Args:
+        verbose (bool):
+            Whether to warn when the kernel is unavailable.
+            (Default is ``True``)
+
+    Returns:
+        (bool):
+            ``True`` if ``import local_corr`` succeeds.
+    """
+    try:
+        import local_corr  ## noqa: F401
+        return True
+    except ImportError as e:
+        if verbose:
+            warnings.warn(
+                f"RoMa's fused local correlation kernel is unavailable, so the slower "
+                f"pure-PyTorch path will be used. Reason: {e}. The kernel is provided by "
+                f"the 'fused-local-corr' package and needs x86_64 Linux with the CUDA "
+                f"runtime libraries present."
+            )
+        return False
+
+
 class RoMa(ImageRegistrationMethod):
     """
     RoMa-based image registration method.
@@ -1728,10 +1765,14 @@ class RoMa(ImageRegistrationMethod):
             fallback_weight_urls=fallback_weight_urls["dinov2"],
         )
 
+        ## Decided here rather than left to romatch, which only checks the
+        ## platform and would let a Linux machine without the kernel through.
+        use_custom_corr = _fused_local_corr_available(verbose=verbose)
+
         if model_type == 'outdoor':
-            self.model = roma_outdoor(device=device, weights=weights, dinov2_weights=weights_dinov2)
+            self.model = roma_outdoor(device=device, weights=weights, dinov2_weights=weights_dinov2, use_custom_corr=use_custom_corr)
         elif model_type == 'indoor':
-            self.model = roma_indoor(device=device, weights=weights, dinov2_weights=weights_dinov2)
+            self.model = roma_indoor(device=device, weights=weights, dinov2_weights=weights_dinov2, use_custom_corr=use_custom_corr)
     
     def _match(
         self,

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -13,6 +13,7 @@ PACKAGES = [
     'onnx',
     'onnxruntime',
     'optuna',
+    'pandas',
     'psutil',
     'pytest',
     'scipy',
@@ -29,7 +30,7 @@ PACKAGES = [
     'holoviews',
     'jupyter_bokeh',
     'umap',
-    'hdbscan',
+    'fast_hdbscan',
     'kymatio',
 ]
 
@@ -45,7 +46,7 @@ def test_internal_package_tests():
 
     ## List of packages to test
     packages = [
-        'hdbscan',
+        'fast_hdbscan',
         'umap',
         'optuna',
         'cv2',

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -1,0 +1,152 @@
+"""
+Checks on the dependency extras declared in ``pyproject.toml``.
+
+There are two parallel families of extras: pinned (``core``, ``classification``,
+``tracking``, ``all``) and unpinned (the same names with a ``_latest`` suffix).
+The unpinned family exists so that other packages can depend on ROICaT without
+inheriting exact versions. Both families are hand-written, so they can drift
+apart -- and a package silently missing from the unpinned family only shows up
+as an ImportError in somebody else's install.
+
+These tests compare package *names* only. Version constraints are what the two
+families are supposed to differ on.
+"""
+
+from pathlib import Path
+import re
+import tomllib
+
+import pytest
+
+
+PATH_PYPROJECT = Path(__file__).resolve().parent.parent / 'pyproject.toml'
+
+## Pinned extra -> its unpinned counterpart.
+PAIRS_EXTRAS = {
+    'core': 'core_latest',
+    'classification': 'classification_latest',
+    'tracking': 'tracking_latest',
+    'all': 'all_latest',
+    'dev': 'dev_latest',
+}
+
+
+def _load_extras():
+    """
+    Returns:
+        (dict):
+            ``{extra_name: [requirement_string, ...]}`` from ``pyproject.toml``.
+    """
+    if not PATH_PYPROJECT.exists():
+        pytest.skip(f'pyproject.toml not found at {PATH_PYPROJECT}; not a source checkout.')
+    with open(PATH_PYPROJECT, 'rb') as f:
+        return tomllib.load(f)['project']['optional-dependencies']
+
+
+def _resolve(extras, name, _seen=None):
+    """
+    Expands one extra into the set of distribution names it pulls in, following
+    self-references like ``roicat[core]``.
+
+    Args:
+        extras (dict):
+            All optional-dependency groups.
+        name (str):
+            The group to expand.
+
+    Returns:
+        (set):
+            Lowercased distribution names, with ``-`` and ``_`` normalized, and
+            without version constraints, extras or environment markers.
+    """
+    _seen = set() if _seen is None else _seen
+    if name in _seen:
+        return set()  ## Self-referential extras would otherwise recurse forever.
+    _seen.add(name)
+
+    out = set()
+    for req in extras[name]:
+        ## Drop the environment marker; it distinguishes platforms, not packages.
+        req = req.split(';')[0].strip()
+        match = re.match(r'^([A-Za-z0-9_.\-]+)(?:\[([^\]]*)\])?', req)
+        dist, extras_requested = match.group(1), match.group(2)
+        if dist.lower() == 'roicat':
+            for sub in (extras_requested or '').split(','):
+                out |= _resolve(extras, sub.strip(), _seen)
+        else:
+            out.add(dist.lower().replace('_', '-'))
+    return out
+
+
+@pytest.mark.parametrize('extra_pinned, extra_latest', sorted(PAIRS_EXTRAS.items()))
+def test_pinned_and_latest_extras_name_the_same_packages(extra_pinned, extra_latest):
+    """
+    The unpinned family must cover exactly the same packages as the pinned one.
+    """
+    extras = _load_extras()
+    for name in (extra_pinned, extra_latest):
+        assert name in extras, f"pyproject.toml has no '{name}' extra."
+
+    pkgs_pinned = _resolve(extras, extra_pinned)
+    pkgs_latest = _resolve(extras, extra_latest)
+
+    assert pkgs_pinned == pkgs_latest, (
+        f"'{extra_pinned}' and '{extra_latest}' have drifted apart. "
+        f"Only in '{extra_pinned}': {sorted(pkgs_pinned - pkgs_latest)}. "
+        f"Only in '{extra_latest}': {sorted(pkgs_latest - pkgs_pinned)}."
+    )
+
+
+def test_latest_extras_are_unpinned():
+    """
+    A version constraint inside a ``_latest`` extra defeats its purpose: it is
+    the constraint, not the package, that a downstream package cannot satisfy.
+    """
+    extras = _load_extras()
+    constrained = {}
+    for name in PAIRS_EXTRAS.values():
+        for req in extras[name]:
+            body = req.split(';')[0].strip()
+            ## Strip the distribution name and any [extras] before looking for
+            ## a constraint, so 'holoviews[recommended]' does not read as one.
+            rest = re.sub(r'^[A-Za-z0-9_.\-]+(\[[^\]]*\])?', '', body).strip()
+            if rest and not body.lower().startswith('roicat['):
+                constrained.setdefault(name, []).append(req)
+    assert not constrained, f'Version constraints found in unpinned extras: {constrained}'
+
+
+def test_import_time_dependencies_are_declared():
+    """
+    Every package ``import roicat`` needs before any user code runs must be in
+    the ``all`` extra. ``pandas`` was missing for a long time and worked only
+    because seaborn happened to pull it in.
+    """
+    ## Third-party modules imported at module scope somewhere in the chain that
+    ## `import roicat` walks, mapped to the distribution that provides them.
+    MODULES_IMPORT_TIME = {
+        'matplotlib': 'matplotlib',
+        'numpy': 'numpy',
+        'onnx': 'onnx',
+        'onnxruntime': 'onnxruntime',
+        'optuna': 'optuna',
+        'pandas': 'pandas',
+        'PIL': 'pillow',
+        'scipy': 'scipy',
+        'sklearn': 'scikit-learn',
+        'sparse': 'sparse',
+        'torch': 'torch',
+        'torchvision': 'torchvision',
+        'tqdm': 'tqdm',
+        'yaml': 'pyyaml',
+        'cv2': 'opencv-contrib-python-headless',
+        'richfile': 'richfile',
+    }
+    extras = _load_extras()
+    declared = _resolve(extras, 'all')
+    missing = sorted({
+        dist for dist in MODULES_IMPORT_TIME.values()
+        if dist.replace('_', '-') not in declared
+    })
+    assert not missing, (
+        f'Imported at import time but not declared in the "all" extra: {missing}'
+    )

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -120,6 +120,12 @@ def test_import_time_dependencies_are_declared():
     Every package ``import roicat`` needs before any user code runs must be in
     the ``all`` extra. ``pandas`` was missing for a long time and worked only
     because seaborn happened to pull it in.
+
+    The list below describes the *current* import structure, in which
+    ``roicat/__init__.py`` eagerly imports every submodule. If those imports are
+    ever made lazy, fewer packages will be needed at import time and entries
+    here should be removed -- a failure after such a change means the list is
+    stale, not that the change was wrong.
     """
     ## Third-party modules imported at module scope somewhere in the chain that
     ## `import roicat` walks, mapped to the distribution that provides them.

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -156,3 +156,82 @@ def test_import_time_dependencies_are_declared():
     assert not missing, (
         f'Imported at import time but not declared in the "all" extra: {missing}'
     )
+
+
+######################################################################################################################################
+######################################################## PYTHON VERSIONS #############################################################
+######################################################################################################################################
+
+PATH_BUILD_YML = Path(__file__).resolve().parent.parent / '.github' / 'workflows' / 'build.yml'
+
+## Candidate minor versions to ask `requires-python` about. Wide enough that the
+## range does not need revisiting when Python moves on.
+VERSIONS_CANDIDATE = [f'3.{n}' for n in range(8, 30)]
+
+
+def _versions_supported():
+    """
+    Returns:
+        (set): the ``3.x`` strings that ``requires-python`` admits.
+    """
+    from packaging.specifiers import SpecifierSet
+
+    if not PATH_PYPROJECT.exists():
+        pytest.skip(f'pyproject.toml not found at {PATH_PYPROJECT}; not a source checkout.')
+    with open(PATH_PYPROJECT, 'rb') as f:
+        spec = SpecifierSet(tomllib.load(f)['project']['requires-python'])
+    return {v for v in VERSIONS_CANDIDATE if spec.contains(v)}
+
+
+def _versions_tested():
+    """
+    Returns:
+        (set): the ``3.x`` strings in the CI build matrix. Commented-out entries
+        are not included -- YAML drops them, which is the intended reading.
+    """
+    import yaml
+
+    if not PATH_BUILD_YML.exists():
+        pytest.skip(f'build.yml not found at {PATH_BUILD_YML}; not a source checkout.')
+    with open(PATH_BUILD_YML, 'r') as f:
+        workflow = yaml.safe_load(f)
+    return {str(v) for v in workflow['jobs']['build']['strategy']['matrix']['python-version']}
+
+
+def test_ci_tests_every_supported_python():
+    """
+    The versions CI runs and the versions ``requires-python`` admits must match.
+
+    Drift in either direction is a problem. A version admitted but not tested is
+    a support claim with nothing behind it; a version tested but not admitted
+    means the install step in that job cannot have run at all, so the job proves
+    nothing while still reporting green. 3.13 spent months commented out of the
+    matrix while the README said it was unsupported and nothing checked either.
+    """
+    supported, tested = _versions_supported(), _versions_tested()
+    assert supported == tested, (
+        f"requires-python admits {sorted(supported)} but CI runs {sorted(tested)}. "
+        f"Only in requires-python: {sorted(supported - tested)}. "
+        f"Only in CI: {sorted(tested - supported)}."
+    )
+
+
+def test_readme_states_the_supported_pythons():
+    """
+    The README's Requirements line is what users actually read, so it must name
+    every supported version and nothing else.
+    """
+    path_readme = Path(__file__).resolve().parent.parent / 'README.md'
+    if not path_readme.exists():
+        pytest.skip(f'README.md not found at {path_readme}; not a source checkout.')
+    line = next(
+        (l for l in path_readme.read_text(encoding='utf-8').splitlines() if '**Python' in l),
+        None,
+    )
+    assert line is not None, "No '**Python ...**' requirements line found in README.md."
+
+    named = set(re.findall(r'3\.\d+', line))
+    assert named == _versions_supported(), (
+        f"README requirements line names {sorted(named)}: {line.strip()!r}, "
+        f"but requires-python admits {sorted(_versions_supported())}."
+    )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2820,3 +2820,48 @@ class Test_Preprocessor_ROI_images:
         preprocessor = Preprocessor_ROI_images(verbose=False)
         with pytest.raises(ValueError, match='3-D'):
             preprocessor.transform_images(ROI_images=np.zeros((36, 36), dtype=np.float32))
+
+
+class Test_reason_fused_local_corr_unavailable:
+    """
+    The helper that decides whether RoMa is given its fused correlation kernel.
+
+    Every test clears the cache on both sides. The helper is ``lru_cache``d, so
+    without that the answer depends on which test ran first, and a cached answer
+    derived from a patched ``sys.modules`` would leak into the rest of the run.
+    """
+
+    @staticmethod
+    def _fn():
+        from roicat.tracking.alignment import _reason_fused_local_corr_unavailable
+        return _reason_fused_local_corr_unavailable
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        self._fn().cache_clear()
+        yield
+        self._fn().cache_clear()
+
+    def test_returns_none_when_kernel_imports(self, monkeypatch):
+        import sys, types
+        monkeypatch.setitem(sys.modules, 'local_corr', types.ModuleType('local_corr'))
+        assert self._fn()() is None
+
+    def test_returns_reason_when_kernel_missing(self, monkeypatch):
+        import sys
+        ## A None entry in sys.modules makes `import local_corr` raise ImportError,
+        ## which is the same failure a machine without the package produces.
+        monkeypatch.setitem(sys.modules, 'local_corr', None)
+        reason = self._fn()()
+        assert isinstance(reason, str) and reason
+
+    def test_answer_is_cached(self, monkeypatch):
+        import sys, types
+        monkeypatch.setitem(sys.modules, 'local_corr', types.ModuleType('local_corr'))
+        assert self._fn()() is None
+        ## The installation cannot change mid-process, so the second call must
+        ## not re-probe even though the module is now unimportable.
+        monkeypatch.setitem(sys.modules, 'local_corr', None)
+        assert self._fn()() is None
+        self._fn().cache_clear()
+        assert isinstance(self._fn()(), str)


### PR DESCRIPTION
Version 1.7.7. Four changes, all aimed at making ROICaT usable as a dependency in other packages.

## Python 3.13 (#649, #652)

`requires-python` moves from `<3.13` to `<3.14`, and CI runs 3.13 across all seven platforms. This was blocking downstream packages that test on 3.13.

Two tests now keep the claim honest: the CI matrix and `requires-python` must agree in both directions, and the README's Requirements line must name exactly the supported set.

## Extras restructured (#650)

The extras are now two parallel families plus one for development:

| family | purpose |
|---|---|
| `core`, `classification`, `tracking`, `all` | exact versions — docs, notebooks, CI, reproducing published results |
| `core_latest`, `classification_latest`, `tracking_latest`, `all_latest` | same packages, no version constraints — for packages that depend on ROICaT |
| `dev`, `dev_latest` | test and notebook tooling |

A pinned dependency propagates its pins to everything downstream, which usually cannot be resolved alongside the downstream package's own requirements. The `_latest` family exists so that consumers are not forced to take `torch==2.13.0` and the rest.

`tests/test_pyproject_extras.py` asserts the two families name the same packages, so they cannot drift apart.

**Behaviour change worth noting in the release:** `jupyter`, `pytest`, `selenium` and `xxhash` moved out of `core`/`all` into the new `dev` extra. Anyone running `pip install roicat[all]` and expecting a Jupyter install will no longer get one. `pandas` is now declared — it was imported at import time and only present because seaborn happened to pull it in.

## RoMa's fused kernel (#651)

`fused-local-corr` publishes x86_64 Linux wheels only, with no source distribution, so on ARM Linux `romatch-roicat[fused-local-corr]` could not resolve and the whole install failed. It is now requested only where it exists.

Separately, romatch decided whether to use the kernel by checking `sys.platform` alone, so any Linux machine without the CUDA runtime hit an ImportError inside the matcher at match time. ROICaT now checks whether the kernel actually imports and falls back with an explanation.

## Companion release

`romatch-roicat` 0.1.2.post2 is on PyPI: one OpenCV distribution instead of three (`opencv-contrib-python-headless`, which ROICaT already used — the previous mismatch left whichever build pip wrote last), `albumentations` dropped, and an upstream guard for the missing kernel. ROICaT's existing `>=0.1.2.post1` picks it up with no pin change.