### PR TITLE
fix(deps): drop onnx2torch entirely (#660)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ tracking = [
 ]
 all = [
     "roicat[core,classification,tracking]",
-    "onnx2torch==1.5.15",
     "scikit-image==0.26.0",
 ]
 
@@ -125,7 +124,6 @@ tracking_latest = [
 ]
 all_latest = [
     "roicat[core_latest,classification_latest,tracking_latest]",
-    "onnx2torch",
     "scikit-image",
 ]
 

--- a/roicat/util.py
+++ b/roicat/util.py
@@ -1292,7 +1292,7 @@ class RichFile_ROICaT(rf.RichFile):
                 "function_save":      save_repr,
                 "object_class":       Model_SWT,
                 "suffix":             "swt",
-                "library":            "onnx2torch",
+                "library":            "roicat",
                 "versions_supported": [],
             },
             {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2865,3 +2865,69 @@ class Test_reason_fused_local_corr_unavailable:
         assert self._fn()() is None
         self._fn().cache_clear()
         assert isinstance(self._fn()(), str)
+
+
+######################################################################################################################################
+################################################## RICHFILE TYPE REGISTRY ############################################################
+######################################################################################################################################
+
+
+class Test_richfile_type_registry:
+    """
+    Every type registered on RichFile_ROICaT carries a "library" string, and
+    richfile resolves that string to an installed distribution on *every save*
+    in order to stamp a version into the metadata. So a library naming a
+    package ROICaT does not actually depend on is a save-time crash for anyone
+    without it -- see issue #660, where "model_swt" claimed to come from
+    onnx2torch (a package nothing in ROICaT imports, installed only by the
+    `all` extra), which broke saving for every tracking-only install.
+    """
+
+    @staticmethod
+    def _resolve_library(library):
+        """Mirror of the library -> version resolution richfile performs during
+        save. Returns a version string, or raises the way a save would."""
+        import importlib
+        import importlib.metadata
+
+        if library in ('python', 'builtins'):
+            return 'builtin'
+        try:
+            return importlib.metadata.version(library)
+        except importlib.metadata.PackageNotFoundError:
+            ## richfile falls back to importing the module; so do we.
+            return getattr(importlib.import_module(library), '__version__', 'unknown')
+
+    def _registered_properties(self):
+        return util.RichFile_ROICaT().type_lookup.properties
+
+    def test_every_registered_library_is_resolvable(self):
+        """A library string that does not resolve is one that raises on save.
+
+        This has teeth because the test environment is built from ROICaT's own
+        extras: a registration naming a package that is not a ROICaT dependency
+        fails here rather than in a user's pipeline.
+        """
+        unresolvable = {}
+        for prop in self._registered_properties():
+            try:
+                self._resolve_library(prop['library'])
+            except Exception as e:
+                unresolvable[prop['type_name']] = f"{prop['library']!r} -> {type(e).__name__}: {e}"
+        assert not unresolvable, (
+            'These registered types name a library that does not resolve in this '
+            f'environment, so saving them would raise: {unresolvable}'
+        )
+
+    def test_model_swt_is_attributed_to_roicat(self):
+        """Model_SWT is defined in roicat.util. Regression guard for #660."""
+        prop = util.RichFile_ROICaT().type_lookup['model_swt']
+        assert prop['library'] == 'roicat', (
+            f"model_swt should be attributed to roicat, got {prop['library']!r}"
+        )
+
+    def test_no_registration_names_onnx2torch(self):
+        """Nothing in ROICaT imports onnx2torch and it is no longer a
+        dependency, so no type should claim to come from it."""
+        offenders = [p['type_name'] for p in self._registered_properties() if p['library'] == 'onnx2torch']
+        assert not offenders, f'types still attributed to onnx2torch: {offenders}'


### PR DESCRIPTION
Fixes #660.

## The problem

@apasarkar is right, and the issue is worse than "an incorrect label".

`onnx2torch` is imported nowhere in ROICaT. Its only trace in the codebase was the `"library"` field on the `model_swt` richfile type registration — wrong on its face, since `Model_SWT` is defined in `roicat/util.py`.

That field is not cosmetic. richfile resolves it to an installed distribution on **every save**, to stamp a version into the element metadata (`_get_library_version`, called from `save_object`). When the named package is absent, the lookup raises.

Reproduced against richfile 0.6.2 with ROICaT's exact registration shape:

```
library="onnx2torch" -> FAILED: ModuleNotFoundError: No module named 'onnx2torch'
library="roicat"     -> SAVE OK
```

## Blast radius

`onnx2torch` ships only in the `all` / `all_latest` extras — not `tracking` or `tracking_latest`. And `pipelines.py` puts `swt.__dict__` into `run_data`, which is written with `RichFile_ROICaT`; `self.swt` is bound to `util.Model_SWT` and never rebound, and richfile resolves types by exact `type(element)` match, so the `model_swt` entry *is* reached.

So every `roicat[tracking]` user with `dir_save` set lost the run at its final save step. CI never saw it because the matrix builds only `dev` / `dev_latest`, which resolve to `all` and therefore install onnx2torch.

## Changes

- `model_swt` is attributed to `"roicat"`, where `Model_SWT` actually lives.
- `onnx2torch` is removed from the `all` and `all_latest` extras. Nothing imports it, and its `==1.5.15` pin also constrained `onnx`.
- Tests assert every registered `library` resolves in the current environment. That check only has teeth *because* onnx2torch is no longer installed here — which is precisely the coverage gap that hid this.

## Backward compatibility

Loading existing archives is unaffected: richfile dispatches on `metadata["type"]`, never on `library`, and `model_swt` declares no version rules (`versions_supported: []`), so there is no version gate to fail. Files written with the old label load unchanged.

## Note on merge order

This touches the `model_swt` dict literal a few lines from the `function_load`/`function_save` entries that the SWT-serialization PR changes, so whichever merges second needs a trivial rebase. No logical conflict.
