### PR TITLE
feat(swt): serialize the SWT model as JSON instead of its repr

### DIFF
--- a/roicat/tracking/scatteringWaveletTransformer.py
+++ b/roicat/tracking/scatteringWaveletTransformer.py
@@ -7,6 +7,34 @@ from tqdm.auto import tqdm
 
 from .. import helpers, util
 
+
+def import_Scattering2D():
+    """
+    Imports kymatio's torch ``Scattering2D``, applying the scipy compatibility
+    shim it needs first.
+
+    Factored out of :class:`SWT` so that rebuilding a saved model
+    (:meth:`roicat.util.Model_SWT.from_dict`) goes through exactly the same
+    import path as building a fresh one.
+
+    Returns:
+        (type):
+            import_Scattering2D (type):
+                The ``kymatio.torch.Scattering2D`` class.
+    """
+    ## Monkey-patch for scipy >= 1.17 compatibility (sph_harm removed).
+    ## sph_harm(m, n, theta, phi) was replaced by sph_harm_y(n, m, theta, phi)
+    ## with swapped argument order for both (m,n) and (theta,phi).
+    ## Needed on any kymatio import, not just the 2D one: `kymatio.torch` pulls
+    ## in the 3D frontend, whose filter bank imports sph_harm at module scope.
+    import scipy.special
+    if not hasattr(scipy.special, 'sph_harm'):
+        scipy.special.sph_harm = lambda m, n, theta, phi: scipy.special.sph_harm_y(n, m, phi, theta)
+
+    from kymatio.torch import Scattering2D
+    return Scattering2D
+
+
 class SWT(util.ROICaT_Module):
     """
     Performs scattering wavelet transform using the kymatio library.
@@ -57,14 +85,7 @@ class SWT(util.ROICaT_Module):
             ],
         )
 
-        ## Monkey-patch for scipy >= 1.17 compatibility (sph_harm removed).
-        ## sph_harm(m, n, theta, phi) was replaced by sph_harm_y(n, m, theta, phi)
-        ## with swapped argument order for both (m,n) and (theta,phi).
-        import scipy.special
-        if not hasattr(scipy.special, 'sph_harm'):
-            scipy.special.sph_harm = lambda m, n, theta, phi: scipy.special.sph_harm_y(n, m, phi, theta)
-
-        from kymatio.torch import Scattering2D
+        Scattering2D = import_Scattering2D()
 
         self._verbose = verbose
         self._device = device

--- a/roicat/util.py
+++ b/roicat/util.py
@@ -955,6 +955,68 @@ class RichFile_ROICaT(rf.RichFile):
             with open(path, 'r') as f:
                 return f.read()
 
+        ## SWT MODEL
+        def save_model_swt(
+            obj: 'Model_SWT',
+            path: Union[str, Path],
+            **kwargs,
+        ) -> None:
+            """
+            Saves a Model_SWT as JSON describing the wrapped Scattering2D.
+
+            The transform is analytic, so its constructor arguments are a
+            complete record of it -- there are no learned weights to store.
+            Anything that is not a kymatio-backed Model_SWT falls back to the
+            historical repr record rather than failing the whole save.
+            """
+            try:
+                d = obj.to_dict()
+            except Exception as e:
+                warnings.warn(
+                    f"Could not describe {type(obj).__name__} as JSON "
+                    f"({type(e).__name__}: {e}). Saving its repr instead; this "
+                    "object will not reload as a model."
+                )
+                save_repr(obj=obj, path=path, **kwargs)
+                return
+            with open(path, 'w') as f:
+                json.dump(d, f, indent=2)
+
+        def load_model_swt(
+            path: Union[str, Path],
+            **kwargs,
+        ) -> object:
+            """
+            Loads a Model_SWT saved by ``save_model_swt``.
+
+            Returns a rebuilt ``Model_SWT`` for files written by this version.
+            Files written before JSON serialization existed hold a repr string
+            and are returned as that string, exactly as they were before. If a
+            rebuild is not possible here (e.g. kymatio is not installed), the
+            saved parameter dict is returned with a warning -- loading never
+            raises on account of this type, since it never used to.
+            """
+            with open(path, 'r') as f:
+                contents = f.read()
+
+            try:
+                d = json.loads(contents)
+            except json.JSONDecodeError:
+                return contents  ## Legacy repr payload.
+            if not (isinstance(d, dict) and 'kwargs_Scattering2D' in d):
+                return contents
+
+            try:
+                return Model_SWT.from_dict(d)
+            except Exception as e:
+                warnings.warn(
+                    f"Could not rebuild the SWT model ({type(e).__name__}: {e}). "
+                    "Returning its saved parameters instead; "
+                    "`roicat.util.Model_SWT.from_dict` on this dict will "
+                    "reproduce the model once kymatio is available."
+                )
+                return d
+
         ## HDBSCAN OBJECT (fast_hdbscan or legacy)
         import fast_hdbscan
         _hdbscan_class = fast_hdbscan.HDBSCAN
@@ -1288,8 +1350,8 @@ class RichFile_ROICaT(rf.RichFile):
             },
             {
                 "type_name":          "model_swt",
-                "function_load":      load_repr,
-                "function_save":      save_repr,
+                "function_load":      load_model_swt,
+                "function_save":      save_model_swt,
                 "object_class":       Model_SWT,
                 "suffix":             "swt",
                 "library":            "roicat",
@@ -1394,11 +1456,108 @@ class JSON_List(list):
 
 ## Wrapper for SWT
 class Model_SWT(torch.nn.Module):
+    """
+    Wraps a kymatio ``Scattering2D`` so it can be used (and serialized) as a
+    regular ``torch.nn.Module``.
+
+    The wrapped transform holds no learned state: kymatio derives its entire
+    filter bank analytically from the constructor arguments below, so recording
+    those arguments is a complete description of the model. That is what
+    :meth:`to_dict` / :meth:`from_dict` do, and it is why a rebuilt model is
+    equivalent to the original rather than an approximation of it.
+    """
+
+    ## Constructor arguments of kymatio's Scattering2D that fully determine the
+    ## filter bank. kymatio stores each under an attribute of the same name.
+    ## `backend` is deliberately excluded: kymatio replaces the string with an
+    ## imported module object during __init__, so it is neither JSON-safe nor
+    ## meaningful to persist (it is re-resolved from the default on rebuild).
+    _KEYS_SCATTERING2D = ('J', 'shape', 'L', 'max_order', 'pre_pad', 'out_type')
+
     def __init__(self, model: torch.nn.Module):
         super(Model_SWT, self).__init__()
         self.add_module('model', model)
     def forward(self, x):
         return self.model(x)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Returns a JSON-serializable description of the wrapped transform.
+
+        Returns:
+            (Dict[str, Any]):
+                to_dict (Dict[str, Any]):
+                    Dictionary with the wrapped class name, the Scattering2D
+                    constructor arguments, and the device the model is on.
+
+        Raises:
+            TypeError:
+                If the wrapped model is not a kymatio ``Scattering2D`` (or does
+                not otherwise expose the expected constructor attributes), in
+                which case there is nothing meaningful to record.
+        """
+        inner = self.model
+        missing = [k for k in self._KEYS_SCATTERING2D if not hasattr(inner, k)]
+        if missing:
+            raise TypeError(
+                f"Cannot describe wrapped model of type {type(inner).__name__}: "
+                f"missing expected Scattering2D attributes {missing}."
+            )
+
+        kwargs = {k: getattr(inner, k) for k in self._KEYS_SCATTERING2D}
+        ## Coerce to plain Python types; kymatio may hold numpy scalars/tuples.
+        kwargs['shape'] = [int(v) for v in kwargs['shape']]
+        kwargs['J'] = int(kwargs['J'])
+        kwargs['L'] = int(kwargs['L'])
+        kwargs['max_order'] = int(kwargs['max_order'])
+        kwargs['pre_pad'] = bool(kwargs['pre_pad'])
+        kwargs['out_type'] = str(kwargs['out_type'])
+
+        ## The filters live in buffers, so they carry the model's device.
+        device = next((str(b.device) for b in self.buffers()), 'cpu')
+
+        return {
+            'class_wrapped': type(inner).__name__,
+            'kwargs_Scattering2D': kwargs,
+            'device': device,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> 'Model_SWT':
+        """
+        Rebuilds a Model_SWT from the output of :meth:`to_dict`.
+
+        Args:
+            d (Dict[str, Any]):
+                Dictionary produced by :meth:`to_dict`.
+
+        Returns:
+            (Model_SWT):
+                from_dict (Model_SWT):
+                    A model whose filter bank is identical to the original's,
+                    since kymatio computes it deterministically from the
+                    recorded arguments.
+        """
+        ## Imported here rather than at module scope: roicat.util is imported by
+        ## the tracking subpackage, so a top-level import would be circular, and
+        ## kymatio is only needed when a model is actually being rebuilt.
+        from .tracking.scatteringWaveletTransformer import import_Scattering2D
+
+        kwargs = dict(d['kwargs_Scattering2D'])
+        kwargs['shape'] = tuple(kwargs['shape'])
+        model = cls(import_Scattering2D()(**kwargs))
+
+        ## Restore the original device when it is available, but never fail over
+        ## it: an archive written on a GPU machine must still load on a CPU one.
+        device = d.get('device', 'cpu')
+        try:
+            model.to(device)
+        except Exception as e:
+            warnings.warn(
+                f"Could not place the rebuilt SWT model on its original device "
+                f"{device!r} ({type(e).__name__}: {e}). Leaving it on CPU."
+            )
+        return model
 
 
 def make_session_bool(n_roi: np.ndarray,) -> np.ndarray:

--- a/roicat/util.py
+++ b/roicat/util.py
@@ -1513,13 +1513,21 @@ class Model_SWT(torch.nn.Module):
         kwargs['pre_pad'] = bool(kwargs['pre_pad'])
         kwargs['out_type'] = str(kwargs['out_type'])
 
-        ## The filters live in buffers, so they carry the model's device.
-        device = next((str(b.device) for b in self.buffers()), 'cpu')
+        ## The filters live in buffers, so they carry the model's device and
+        ## dtype. Both must be recorded: kymatio builds its filter bank in a
+        ## fixed default dtype, and its Fourier ops require the input and the
+        ## filters to match ("Input and filter must be of the same dtype"), so a
+        ## model that had been cast with .double()/.half() would otherwise come
+        ## back silently narrowed and reject the inputs the original accepted.
+        buffer_first = next(iter(self.buffers()), None)
+        device = 'cpu' if buffer_first is None else str(buffer_first.device)
+        dtype = None if buffer_first is None else str(buffer_first.dtype).split('.')[-1]
 
         return {
             'class_wrapped': type(inner).__name__,
             'kwargs_Scattering2D': kwargs,
             'device': device,
+            'dtype': dtype,
         }
 
     @classmethod
@@ -1546,6 +1554,21 @@ class Model_SWT(torch.nn.Module):
         kwargs = dict(d['kwargs_Scattering2D'])
         kwargs['shape'] = tuple(kwargs['shape'])
         model = cls(import_Scattering2D()(**kwargs))
+
+        ## Restore the original dtype. kymatio builds its filters in a fixed
+        ## default, so a model that had been cast with .double()/.half() would
+        ## otherwise come back narrowed and reject the inputs the original
+        ## accepted. Absent from archives written before dtype was recorded, in
+        ## which case kymatio's default is already correct.
+        dtype = d.get('dtype')
+        if dtype is not None:
+            try:
+                model.to(dtype=getattr(torch, dtype))
+            except Exception as e:
+                warnings.warn(
+                    f"Could not restore the rebuilt SWT model's dtype {dtype!r} "
+                    f"({type(e).__name__}: {e}). Leaving it at kymatio's default."
+                )
 
         ## Restore the original device when it is available, but never fail over
         ## it: an archive written on a GPU machine must still load on a CPU one.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2931,3 +2931,115 @@ class Test_richfile_type_registry:
         dependency, so no type should claim to come from it."""
         offenders = [p['type_name'] for p in self._registered_properties() if p['library'] == 'onnx2torch']
         assert not offenders, f'types still attributed to onnx2torch: {offenders}'
+
+
+######################################################################################################################################
+##################################################### MODEL_SWT SERIALIZATION ########################################################
+######################################################################################################################################
+
+
+class Test_Model_SWT_serialization:
+    """
+    Model_SWT used to be written into richfiles as its repr -- a 38-byte string
+    like ``'Model_SWT(\\n  (model): Scattering2D()\\n)'`` -- which recorded
+    neither J, L, shape nor device, and loaded back as that string rather than
+    as a model. These tests pin the JSON round trip that replaced it, and pin
+    that files written the old way still load the old way.
+    """
+
+    SHAPE = (36, 36)
+
+    def _make_model(self):
+        from roicat.tracking import scatteringWaveletTransformer as swt_module
+        Scattering2D = swt_module.import_Scattering2D()
+        return util.Model_SWT(Scattering2D(shape=self.SHAPE, J=2, L=8))
+
+    def _save_load(self, obj, tmp_path, name='payload.richfile'):
+        path = str(Path(tmp_path) / name)
+        util.RichFile_ROICaT(path=path, backend='directory').save({'swt': obj}, overwrite=True)
+        return util.RichFile_ROICaT(path=path).load()['swt']
+
+    def test_to_dict_captures_constructor_args_and_is_json_safe(self):
+        import json
+
+        d = self._make_model().to_dict()
+        assert d['kwargs_Scattering2D']['J'] == 2
+        assert d['kwargs_Scattering2D']['L'] == 8
+        assert tuple(d['kwargs_Scattering2D']['shape']) == self.SHAPE
+        ## `backend` becomes a module object inside kymatio, so it must not be
+        ## recorded; if it leaked in, this dump would raise.
+        assert 'backend' not in d['kwargs_Scattering2D']
+        json.dumps(d)
+
+    def test_round_trip_returns_an_equivalent_model(self, tmp_path):
+        """The point of the change: what comes back is a model, not a string."""
+        model = self._make_model()
+        loaded = self._save_load(model, tmp_path)
+
+        assert isinstance(loaded, util.Model_SWT), (
+            f'expected a Model_SWT back, got {type(loaded).__name__}'
+        )
+
+        ## kymatio derives its filter bank analytically, so a rebuilt model's
+        ## buffers should be bit-identical, not merely close.
+        buffers_original = dict(model.named_buffers())
+        buffers_loaded = dict(loaded.named_buffers())
+        assert set(buffers_original) == set(buffers_loaded), 'filter bank differs in structure'
+        for k in buffers_original:
+            np.testing.assert_array_equal(
+                buffers_original[k].numpy(), buffers_loaded[k].numpy(),
+                err_msg=f'filter buffer {k!r} differs after round trip',
+            )
+
+    def test_round_trip_preserves_the_transform(self, tmp_path):
+        """Identical filters should mean identical outputs on the same input."""
+        model = self._make_model()
+        loaded = self._save_load(model, tmp_path)
+
+        rng = np.random.RandomState(0)
+        x = torch.as_tensor(rng.randn(2, *self.SHAPE).astype(np.float32)).contiguous()
+        with torch.no_grad():
+            np.testing.assert_array_equal(model(x).numpy(), loaded(x).numpy())
+
+    def test_legacy_repr_payload_loads_unchanged(self, tmp_path):
+        """Archives written before this change hold a repr string under the
+        same type name. They must keep loading, and keep returning the string
+        they always returned."""
+        legacy = 'Model_SWT(\n  (model): Scattering2D()\n)'
+        path = Path(tmp_path) / 'legacy.swt'
+        path.write_text(legacy)
+
+        function_load = util.RichFile_ROICaT().type_lookup['model_swt']['function_load']
+        assert function_load(path=str(path)) == legacy
+
+    def test_load_degrades_to_params_without_kymatio(self, tmp_path, monkeypatch):
+        """Rebuilding needs kymatio. Not having it must not turn a load that
+        used to succeed into an exception -- warn and hand back the params."""
+        import sys
+
+        model = self._make_model()
+        path = Path(tmp_path) / 'model.swt'
+        function_save = util.RichFile_ROICaT().type_lookup['model_swt']['function_save']
+        function_load = util.RichFile_ROICaT().type_lookup['model_swt']['function_load']
+        function_save(obj=model, path=str(path))
+
+        ## A None entry in sys.modules makes the import raise ImportError, which
+        ## is the same failure a machine without kymatio produces.
+        monkeypatch.setitem(sys.modules, 'kymatio', None)
+        monkeypatch.setitem(sys.modules, 'kymatio.torch', None)
+
+        with pytest.warns(UserWarning):
+            out = function_load(path=str(path))
+        assert isinstance(out, dict) and 'kwargs_Scattering2D' in out
+
+    def test_non_kymatio_model_falls_back_to_repr(self, tmp_path):
+        """Model_SWT is a generic wrapper. Wrapping something that is not a
+        Scattering2D should degrade to the old repr record rather than break
+        the entire save."""
+        wrapped = util.Model_SWT(torch.nn.Linear(2, 2))
+        path = Path(tmp_path) / 'other.swt'
+        function_save = util.RichFile_ROICaT().type_lookup['model_swt']['function_save']
+
+        with pytest.warns(UserWarning):
+            function_save(obj=wrapped, path=str(path))
+        assert path.read_text().startswith('Model_SWT(')

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3001,6 +3001,35 @@ class Test_Model_SWT_serialization:
         with torch.no_grad():
             np.testing.assert_array_equal(model(x).numpy(), loaded(x).numpy())
 
+    def test_round_trip_preserves_dtype(self, tmp_path):
+        """A model cast with .double() must come back as float64.
+
+        kymatio builds its filter bank in a fixed default dtype, and its Fourier
+        ops require input and filters to match ("Input and filter must be of the
+        same dtype"). Recording only the device would silently narrow a cast
+        model on reload, so it would reject the very inputs the original
+        accepted -- a wrong answer rather than an error.
+        """
+        model = self._make_model().double()
+        assert next(iter(model.buffers())).dtype == torch.float64
+
+        loaded = self._save_load(model, tmp_path)
+        assert next(iter(loaded.buffers())).dtype == torch.float64, (
+            'dtype was not preserved through the round trip'
+        )
+
+        rng = np.random.RandomState(0)
+        x = torch.as_tensor(rng.randn(2, *self.SHAPE)).double().contiguous()
+        with torch.no_grad():
+            np.testing.assert_array_equal(model(x).numpy(), loaded(x).numpy())
+
+    def test_load_without_recorded_dtype_still_works(self, tmp_path):
+        """Payloads written before dtype was recorded must still rebuild."""
+        d = self._make_model().to_dict()
+        d.pop('dtype')
+        rebuilt = util.Model_SWT.from_dict(d)
+        assert isinstance(rebuilt, util.Model_SWT)
+
     def test_legacy_repr_payload_loads_unchanged(self, tmp_path):
         """Archives written before this change hold a repr string under the
         same type name. They must keep loading, and keep returning the string


### PR DESCRIPTION
## The problem

`Model_SWT` was registered in the richfile type registry with `save_repr`/`load_repr`.

kymatio's `Scattering2D` holds **no learned state**. `build()` and `create_filters()` derive the entire filter bank analytically from `(J, shape, L, max_order, pre_pad, out_type)` via `filter_bank()`, which is deterministic.

This follows the `to_dict()`/`from_dict()` + JSON idiom this registry already uses for `similarity_metric` and `preprocessor_roi_images`.

## What changed

- `Model_SWT` gains `to_dict()` / `from_dict()`. `backend` is deliberately excluded: kymatio replaces the string with an imported module object during `__init__`, so it is neither JSON-safe nor meaningful to persist.
- `save_model_swt` / `load_model_swt` replace `save_repr` / `load_repr` for this type.
- The kymatio import — and the `scipy>=1.17` `sph_harm` shim it needs, since `kymatio.torch` pulls in the 3D frontend — is factored into `scatteringWaveletTransformer.import_Scattering2D()`, so rebuilding a saved model uses the same import path as building a fresh one.

## Tests

Round trip through a real `RichFile_ROICaT` asserting bit-identical filter buffers and an identical transform on the same input; a legacy repr payload still loading unchanged; graceful degradation to the params dict with kymatio blocked; and fallback to repr when `Model_SWT` wraps something that is not a `Scattering2D`.