### PR TITLE
fix: stop requiring IPython to import roicat

### DIFF
--- a/roicat/helpers.py
+++ b/roicat/helpers.py
@@ -289,6 +289,29 @@ def flatten_dict(d: MutableMapping, parent_key: str = '', sep: str ='.') -> Muta
             items.append((new_key, v))
     return dict(items)
 
+def display_or_print(obj: Any) -> None:
+    """
+    Shows ``obj`` using IPython's rich display when IPython is importable, and
+    falls back to ``print`` when it is not.
+
+    IPython is not a ROICaT dependency. It arrives transitively with Jupyter,
+    which only the notebook-facing extras pull in, so it is absent from a
+    plain ``roicat[tracking]`` install. Importing it at module scope is
+    therefore not safe; this wrapper keeps the nicer notebook rendering
+    without making a headless install impossible.
+
+    Args:
+        obj (Any):
+            Object to display.
+    """
+    try:
+        from IPython.display import display
+    except ImportError:
+        print(obj)
+    else:
+        display(obj)
+
+
 ## parameter dictionary helpers ##
 
 def fill_in_dict(

--- a/roicat/pipelines.py
+++ b/roicat/pipelines.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 import copy
 import tempfile
-from IPython.display import display
 import time
 
 # import matplotlib.pyplot as plt
@@ -46,7 +45,7 @@ def pipeline_tracking(params: dict, custom_data: data_importing.Data_roicat = No
     ## Prepare params
     defaults = util.get_default_parameters(pipeline='tracking')
     params = helpers.prepare_params(params, defaults, verbose=True)
-    display(params)
+    helpers.display_or_print(params)
 
     ## Prepare state variables
     VERBOSE = params['general']['verbose']

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2865,3 +2865,92 @@ class Test_reason_fused_local_corr_unavailable:
         assert self._fn()() is None
         self._fn().cache_clear()
         assert isinstance(self._fn()(), str)
+
+
+######################################################################################################################################
+###################################################### OPTIONAL IPYTHON ##############################################################
+######################################################################################################################################
+
+
+class Test_ipython_is_optional:
+    """
+    ``roicat/pipelines.py`` imported ``IPython.display.display`` at module
+    scope, and ``roicat/__init__.py`` imports ``pipelines``, so ``import
+    roicat`` required IPython. IPython is in no extra -- it arrives only
+    transitively with Jupyter -- so a plain ``roicat[tracking]`` install could
+    not import the package at all. CI missed it because the `dev` extra
+    installs jupyter.
+    """
+
+    def test_no_module_scope_ipython_import_anywhere_in_roicat(self):
+        """Static guard: IPython may be imported inside a function, never at
+        module scope, since module scope runs on `import roicat`."""
+        import ast
+        import roicat
+
+        root = Path(roicat.__file__).parent
+        offenders = []
+        for path in sorted(root.rglob('*.py')):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in tree.body:  ## module scope only, not nested scopes
+                names = []
+                if isinstance(node, ast.Import):
+                    names = [a.name for a in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    names = [node.module or '']
+                if any(n == 'IPython' or n.startswith('IPython.') for n in names):
+                    offenders.append(f'{path.relative_to(root)}:{node.lineno}')
+        assert not offenders, (
+            'IPython imported at module scope (breaks `import roicat` without '
+            f'IPython installed): {offenders}'
+        )
+
+    def test_import_roicat_succeeds_without_ipython(self):
+        """The end-to-end check: a fresh interpreter that cannot import
+        IPython must still be able to import roicat."""
+        import subprocess
+        import sys
+        import textwrap
+
+        script = textwrap.dedent(
+            '''
+            import sys
+            from importlib.abc import MetaPathFinder
+
+            class _BlockIPython(MetaPathFinder):
+                """Make IPython unimportable, as it is on a tracking-only install."""
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname == 'IPython' or fullname.startswith('IPython.'):
+                        raise ImportError(f'blocked for test: {fullname}')
+                    return None
+
+            sys.meta_path.insert(0, _BlockIPython())
+            for name in list(sys.modules):
+                if name == 'IPython' or name.startswith('IPython.'):
+                    del sys.modules[name]
+
+            import roicat
+            import roicat.pipelines
+            print('IMPORT_OK')
+            '''
+        )
+        result = subprocess.run(
+            [sys.executable, '-c', script],
+            capture_output=True, text=True, timeout=600,
+        )
+        assert 'IMPORT_OK' in result.stdout, (
+            f'importing roicat without IPython failed:\n'
+            f'--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}'
+        )
+
+    def test_display_or_print_falls_back_to_print(self, monkeypatch, capsys):
+        """Without IPython the helper must still show the object."""
+        import sys
+
+        ## A None entry in sys.modules makes the import raise ImportError, the
+        ## same failure a machine without IPython produces.
+        monkeypatch.setitem(sys.modules, 'IPython', None)
+        monkeypatch.setitem(sys.modules, 'IPython.display', None)
+
+        helpers.display_or_print({'a': 1})
+        assert 'a' in capsys.readouterr().out


### PR DESCRIPTION
## The problem

`roicat/pipelines.py` imported `IPython.display.display` at module scope, and `roicat/__init__.py` does `from . import pipelines`. So **`import roicat` required IPython**.

IPython appears in no extra in `pyproject.toml`. It arrives only transitively with `jupyter`, which the notebook-facing extras install. So `pip install roicat[tracking]` produced a package that could not be imported at all.

CI missed it because the `dev` extra installs `jupyter`.

## The fix, and why not just add the dependency

The import existed for a single call — `display(params)` — which pretty-prints the resolved parameter dict once per pipeline run.

Promoting IPython to a hard dependency for that would put a notebook stack (traitlets, prompt_toolkit, pygments, jedi, …) into every headless and HPC install. `roicat/visualization.py` already treats IPython as optional in two places — a lazy in-function import at line 46, and a `try/except` with a print fallback at 425 — so `pipelines.py` was the outlier, not the precedent.

This routes the call through `helpers.display_or_print`, which uses IPython's rich display when importable and falls back to `print` when not.

## Tests

- A static AST guard that no module in `roicat/` imports IPython at module scope (module scope is what runs on `import roicat`; in-function imports remain fine).
- An end-to-end check that a fresh interpreter with IPython blocked via `sys.meta_path` can still `import roicat`. **This is the one that would have caught the bug** — the existing suite structurally could not, since the test environment installs jupyter.
- A unit test of the print fallback.

## Related

An audit of module-scope third-party imports across all 24 modules in `roicat/` found exactly two that are not `core` dependencies: this one, and `roicat/tracking/alignment.py:14` importing `cv2` (filed as #662). `kymatio`, `kornia`, `romatch` and `roiextractors` are all correctly imported lazily.
