### PR TITLE
chore: stop shipping a notebook environment, and fix the notebook paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,18 @@ documentation.
 <br>
 **Note on opencv:** The headless version of opencv is installed by default. If
 the regular version is already installed, you will need to uninstall it first.
+<br>
+**Note on notebooks:** ROICaT installs the libraries the notebooks *use*, but
+not a notebook environment to run them in, since setups vary too much for one
+choice to suit everyone. To run the notebooks, install whichever you prefer into
+the same environment, for example `pip install jupyterlab` or
+`pip install notebook`.
 
 ### 3. Clone the repo to get the notebooks
 ```
 git clone https://github.com/RichieHakim/ROICaT
 ```
-Then, navigate to the `ROICaT/notebooks/jupyter` directory to run the notebooks.
+Then, navigate to the `ROICaT/notebooks` directory to run the notebooks.
 
 
 # Quick Start

--- a/docs/source/inputsAndOutputs.rst
+++ b/docs/source/inputsAndOutputs.rst
@@ -7,7 +7,7 @@ Inputs
 - **Suite2p output files:** ``stat.npy`` and ``ops.npy`` files only.
 - **Other data formats:** Support for formats like CaImAn, custom ROIs, etc.,
   can be facilitated through a custom data importing notebook found `here
-  <https://github.com/RichieHakim/ROICaT/blob/main/notebooks/jupyter/other/demo_data_importing.ipynb>`_.
+  <https://github.com/RichieHakim/ROICaT/blob/main/notebooks/other/demo_data_importing.ipynb>`_.
 
 -------
 

--- a/notebooks/classification/A1_classify_by_drawingSelection.ipynb
+++ b/notebooks/classification/A1_classify_by_drawingSelection.ipynb
@@ -197,7 +197,7 @@
    "metadata": {},
    "source": [
     "In this example we are using suite2p output files, but other data types can be used (CaImAn, etc.) \\\n",
-    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/jupyter/other/demo_custom_data_importing.ipynb\n",
+    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/other/demo_data_importing.ipynb\n",
     "\n",
     "Make a list containing the paths to all the input files.\n",
     "\n",

--- a/notebooks/classification/B1a_labeling_interactive.ipynb
+++ b/notebooks/classification/B1a_labeling_interactive.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "source": [
     "In this example we are using suite2p output files, but other data types can be used (CaImAn, etc.) \\\n",
-    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/jupyter/other/demo_data_importing.ipynb\n",
+    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/other/demo_data_importing.ipynb\n",
     "\n",
     "Make a list containing the paths to all the input files.\n",
     "\n",

--- a/notebooks/classification/B1b_labeling_drawingAndInteractive.ipynb
+++ b/notebooks/classification/B1b_labeling_drawingAndInteractive.ipynb
@@ -130,7 +130,7 @@
    "metadata": {},
    "source": [
     "In this example we are using suite2p output files, but other data types can be used (CaImAn, etc.) \\\n",
-    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/jupyter/other/demo_data_importing.ipynb\n",
+    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/other/demo_data_importing.ipynb\n",
     "\n",
     "Make a list containing the paths to all the input files.\n",
     "\n",

--- a/notebooks/classification/B2_classifier_train_interactive.ipynb
+++ b/notebooks/classification/B2_classifier_train_interactive.ipynb
@@ -146,7 +146,7 @@
    "source": [
     "## Option 2: Make a new data object\n",
     "\n",
-    "See the [demo_data_importing](https://github.com/RichieHakim/ROICaT/blob/dev/notebooks/jupyter/other/demo_data_importing.ipynb) notebook to build a custom data object using any kind of data (Suite2p, CaImAn, etc.). It's really easy!\n",
+    "See the [demo_data_importing](https://github.com/RichieHakim/ROICaT/blob/dev/notebooks/other/demo_data_importing.ipynb) notebook to build a custom data object using any kind of data (Suite2p, CaImAn, etc.). It's really easy!\n",
     "\n",
     "For example:\n",
     "```\n",

--- a/notebooks/classification/B3_classifier_inference_interactive.ipynb
+++ b/notebooks/classification/B3_classifier_inference_interactive.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "source": [
     "In this example we are using suite2p output files, but other data types can be used (CaImAn, etc.) \\\n",
-    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/jupyter/other/demo_custom_data_importing.ipynb\n",
+    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/other/demo_data_importing.ipynb\n",
     "\n",
     "Make a list containing the paths to all the input files.\n",
     "\n",

--- a/notebooks/tracking/1_tracking_interactive_notebook copy.ipynb
+++ b/notebooks/tracking/1_tracking_interactive_notebook copy.ipynb
@@ -189,7 +189,7 @@
    "metadata": {},
    "source": [
     "In this example we are using suite2p output files, but other data types can be used (CaImAn, etc.) \\\n",
-    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/jupyter/other/demo_data_importing.ipynb\n",
+    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/other/demo_data_importing.ipynb\n",
     "\n",
     "Make a list containing the paths to all the input files.\n",
     "\n",

--- a/notebooks/tracking/1_tracking_interactive_notebook.ipynb
+++ b/notebooks/tracking/1_tracking_interactive_notebook.ipynb
@@ -189,7 +189,7 @@
    "metadata": {},
    "source": [
     "In this example we are using suite2p output files, but other data types can be used (CaImAn, etc.) \\\n",
-    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/jupyter/other/demo_data_importing.ipynb\n",
+    "See the notebook on ingesting diverse data: https://github.com/RichieHakim/ROICaT/blob/main/notebooks/other/demo_data_importing.ipynb\n",
     "\n",
     "Make a list containing the paths to all the input files.\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,14 +134,12 @@ all_latest = [
 ## runner it must then match.
 dev = [
     "roicat[all]",
-    "jupyter==1.1.1",
     "pytest==9.1.1",
     "selenium==4.46.0",
     "xxhash==3.8.1",
 ]
 dev_latest = [
     "roicat[all_latest]",
-    "jupyter",
     "pytest",
     "selenium",
     "xxhash",

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -5,7 +5,6 @@ PACKAGES = [
     'PIL',
     'cpuinfo',
     'cv2',
-    'jupyter',
     'mat73',
     'matplotlib',
     'natsort',

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -277,6 +277,29 @@ def test_no_extra_declares_a_notebook_environment(extra):
     )
 
 
+@pytest.mark.parametrize('extra', ['classification', 'classification_latest', 'all', 'all_latest'])
+def test_classification_declares_the_bokeh_widget_renderer(extra):
+    """
+    `jupyter-bokeh` must stay declared wherever the drawing notebook's plots are.
+
+    Its name makes it look like notebook-environment tooling, and it was removed
+    once on that basis. This pins why it is not.
+    `visualization.select_region_scatterPlot` calls `hv.extension('bokeh')`,
+    holoviews calls `pn.extension()` (holoviews/util/__init__.py), and panel's
+    `config._detect_comms` imports `jupyter_bokeh` when it detects Colab or
+    VSCode -- warning that interactive output will not render without it. In
+    plain JupyterLab it genuinely is not needed, but
+    `A1_classify_by_drawingSelection.ipynb` carries a Colab badge in the README
+    and installs `roicat[classification]` in its own Colab cell, so dropping it
+    breaks a workflow ROICaT advertises.
+    """
+    extras = _load_extras()
+    assert 'jupyter-bokeh' in _resolve(extras, extra), (
+        f"extra '{extra}' no longer declares jupyter-bokeh; the drawing notebook "
+        'will not render interactively in Colab or VSCode.'
+    )
+
+
 def test_documented_notebook_paths_exist():
     """
     Every notebook path named in the README, the docs, or a notebook's own

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -235,3 +235,71 @@ def test_readme_states_the_supported_pythons():
         f"README requirements line names {sorted(named)}: {line.strip()!r}, "
         f"but requires-python admits {sorted(_versions_supported())}."
     )
+
+
+## Packages that *are* a notebook environment: a kernel to execute cells, or a
+## server/UI to open them in. ROICaT deliberately ships none of these, because
+## notebook setups vary too much for one choice to suit everyone -- users bring
+## their own.
+##
+## The line is between an environment and a library. Rendering packages are not
+## on this list even when their names say "jupyter": `jupyter-bokeh` is part of
+## ROICaT's plotting stack (it is what renders bokeh output as a widget), so it
+## is a declared dependency like bokeh and holoviews. What it pulls in
+## transitively -- ipywidgets, and IPython -- is a consequence of that choice,
+## not a notebook environment ROICaT is providing.
+DISTS_NOTEBOOK_ENVIRONMENT = {
+    'jupyter',
+    'jupyterlab',
+    'notebook',
+    'jupyter-server',
+    'ipykernel',
+}
+
+
+@pytest.mark.parametrize('extra', sorted(set(PAIRS_EXTRAS) | set(PAIRS_EXTRAS.values())))
+def test_no_extra_declares_a_notebook_environment(extra):
+    """
+    No extra should install a notebook stack.
+
+    `jupyter` sat in the `dev` extra used by nothing: `tests/test_interactive.py`
+    drives bokeh's own server via selenium, not a kernel. Meanwhile no extra
+    provided an actual kernel or server, so following the README literally left a
+    user unable to open the notebooks it points them at -- enough notebook
+    machinery to be load-bearing by accident, not enough to be useful.
+    """
+    extras = _load_extras()
+    declared = _resolve(extras, extra)
+    offenders = sorted(declared & DISTS_NOTEBOOK_ENVIRONMENT)
+    assert not offenders, (
+        f"extra '{extra}' declares notebook-environment packages {offenders}. "
+        'ROICaT does not provide a notebook environment; users install their own.'
+    )
+
+
+def test_documented_notebook_paths_exist():
+    """
+    Every notebook path named in the README, the docs, or a notebook's own
+    cross-links must exist.
+
+    The README told users to `cd` into `ROICaT/notebooks/jupyter`, a directory
+    deleted in 790ba8a, and several notebooks linked to a
+    `demo_custom_data_importing.ipynb` that has never existed. Both are invisible
+    to every other test, because nothing imports a markdown link.
+    """
+    root = PATH_PYPROJECT.parent
+    if not (root / 'notebooks').is_dir():
+        pytest.skip('notebooks/ not present; not a source checkout.')
+
+    sources = [root / 'README.md']
+    sources += sorted((root / 'docs').rglob('*.rst')) if (root / 'docs').is_dir() else []
+    sources += sorted((root / 'notebooks').rglob('*.ipynb'))
+
+    missing = []
+    for path in sources:
+        text = path.read_text(encoding='utf-8', errors='ignore')
+        ## Any reference to a path under notebooks/, with or without a URL prefix.
+        for ref in set(re.findall(r'notebooks/[A-Za-z0-9_./\- ]*?\.ipynb', text)):
+            if not (root / ref).exists():
+                missing.append(f'{path.relative_to(root)} -> {ref}')
+    assert not missing, f'Documented notebook paths that do not exist: {sorted(missing)}'


### PR DESCRIPTION
Per @RichieHakim: ROICaT should install the libraries its notebooks *use*, but not a notebook environment to run them in.

## What the documented path did

Following the README literally — `conda create -n roicat python=3.12`, `pip install roicat[all]`, clone the repo — pip's resolver returns 171 packages with **no ipykernel, no jupyter, no jupyterlab and no server**. The user could not open the notebooks the very next README line points them at. That line pointed at `ROICaT/notebooks/jupyter`, a directory deleted in 790ba8a.

Enough notebook machinery to be load-bearing by accident, not enough to be useful.

## Removed: `jupyter` (from `dev` / `dev_latest`)

Nothing used it. `tests/test_interactive.py` drives **bokeh's own server** (`bokeh.server.server.Server`) with selenium; it never starts a kernel. Also dropped from the `PACKAGES` list in `tests/test_packages.py`, which would otherwise warn about it forever.

## Kept: `jupyter-bokeh` — and this PR initially got that wrong

The first pass removed `jupyter-bokeh` too, on the grounds that its name says "jupyter" and ROICaT imports it nowhere. That was wrong, and it is restored.

It is not a notebook environment; it is what renders the drawing notebook's plots:

- `visualization.select_region_scatterPlot` calls `hv.extension('bokeh')`
- holoviews calls `pn.extension()` (`holoviews/util/__init__.py:775`)
- panel's `config._detect_comms` imports `jupyter_bokeh` when it detects **Colab** or **VSCode**, and warns that interactive output will not render without it

In plain JupyterLab the default Jupyter extension path is used and it genuinely is not needed — which is precisely what made it look removable. But `A1_classify_by_drawingSelection.ipynb` is the one notebook that draws with holoviews/bokeh, it carries a Colab badge in the README, and its own Colab cell runs `pip install roicat[classification]`. Dropping it breaks a workflow ROICaT advertises.

So the line is between an **environment** and a **library**: `jupyter` provided a kernel and a server nobody used; `jupyter-bokeh` renders output ROICaT itself produces.

## Also kept

`bokeh` and `holoviews[recommended]` are imported at `helpers.py:3402-3403` and `visualization.py:422`. `holoviews[recommended]` resolves to only matplotlib and plotly — no notebook packages. `selenium` and `umap-learn` are unrelated.

## Documentation

- README now states that ROICaT installs the libraries the notebooks use but not an environment to run them in, with `pip install jupyterlab` as the example.
- Fixed 9 references to the deleted `notebooks/jupyter/` directory and 2 links to `demo_custom_data_importing.ipynb`, which has never existed.

## Tests

- `test_no_extra_declares_a_notebook_environment` — no extra may declare a kernel or a server. Scoped to things that *are* an environment, not to anything whose name contains "jupyter".
- `test_classification_declares_the_bokeh_widget_renderer` — pins the reasoning above so `jupyter-bokeh` is not removed again for the reason it was removed here.
- `test_documented_notebook_paths_exist` — every notebook path in the README, the docs, or a notebook cross-link must resolve. Failed on 8 broken links before this change; nothing imports a markdown link, so no existing test could see it.

## Relationship to #665

Independent. `roicat[tracking]` resolves without IPython either way (verified with pip's resolver), so the `pipelines.py` fix in #665 is still required on its own merits — but this PR no longer depends on it.
