### PR TITLE
fix: import OpenCV lazily so roicat imports without it (#662)

### DIFF
--- a/roicat/tracking/alignment.py
+++ b/roicat/tracking/alignment.py
@@ -11,10 +11,37 @@ import scipy.optimize
 import scipy.sparse
 import torch
 from tqdm.auto import tqdm
-import cv2
 import matplotlib.pyplot as plt
 
 from .. import helpers, util
+
+
+def import_cv2():
+    """
+    Imports OpenCV, with an error that says what to install if it is missing.
+
+    OpenCV is only needed by the alignment routines below, but this module used
+    to import it at module scope -- and ``roicat/__init__.py`` imports the
+    tracking subpackage, so that made ``import roicat`` fail outright on any
+    install without OpenCV (e.g. ``roicat[classification]``). Importing it
+    inside the functions that use it keeps the failure local to the feature
+    that needs it.
+
+    Returns:
+        (module):
+            import_cv2 (module):
+                The ``cv2`` module.
+    """
+    try:
+        import cv2
+    except ImportError as e:
+        raise ImportError(
+            "OpenCV is required for ROICaT's image alignment, but is not installed. "
+            "Install it with `pip install roicat[tracking]`, or directly with "
+            "`pip install opencv-contrib-python-headless`."
+        ) from e
+    return cv2
+
 
 class Aligner(util.ROICaT_Module):
     """
@@ -1309,6 +1336,7 @@ def clahe(
             im_out (np.ndarray): 
                 Output image after applying CLAHE.
     """
+    cv2 = import_cv2()
     assert isinstance(grid_size, (int, tuple)), 'grid_size must be int or tuple'
     if isinstance(grid_size, int):
         grid_size = (grid_size, grid_size)
@@ -1470,6 +1498,7 @@ class ImageRegistrationMethod:
         Returns:
             warp_matrix (np.ndarray[3x3]) - the resulting transformation.
         """
+        cv2 = import_cv2()
         # 1) detect & match keypoints
         kptsA, kptsB = self._forward_rigid(im_template, im_moving, **kwargs)
 
@@ -2041,6 +2070,7 @@ class DeepFlow(ImageRegistrationMethod):
         device: str = 'cpu',
         verbose=False,
     ):
+        cv2 = import_cv2()
         super().__init__(device=device, verbose=verbose)
 
         self.model = cv2.optflow.createOptFlow_DeepFlow()
@@ -2126,11 +2156,16 @@ class OpticalFlowFarneback(ImageRegistrationMethod):
         iterations: int = 7,
         poly_n: int = 5,
         poly_sigma: float = 1.5,
-        flags: int = cv2.OPTFLOW_FARNEBACK_GAUSSIAN,  ## == 256
+        flags: Optional[int] = None,  ## None -> cv2.OPTFLOW_FARNEBACK_GAUSSIAN (== 256)
         device: str = 'cpu',
         verbose=False,
     ):
         super().__init__(device=device, verbose=verbose)
+
+        ## Resolved here rather than in the signature: evaluating a cv2 constant
+        ## as a default argument would import OpenCV at module scope again.
+        if flags is None:
+            flags = import_cv2().OPTFLOW_FARNEBACK_GAUSSIAN  ## == 256
 
         self.pyr_scale, self.levels, self.winsize, self.iterations, self.poly_n, self.poly_sigma, self.flags = \
             pyr_scale, levels, winsize, iterations, poly_n, poly_sigma, flags
@@ -2141,6 +2176,7 @@ class OpticalFlowFarneback(ImageRegistrationMethod):
         im_moving: Union[np.ndarray, torch.Tensor],
         **kwargs,
     ):
+        cv2 = import_cv2()
         h, w = im_moving.shape
         x_grid, y_grid = np.meshgrid(np.arange(0., w).astype(np.float32), np.arange(0., h).astype(np.float32), indexing='xy')
 
@@ -2213,6 +2249,7 @@ class SIFT(ImageRegistrationMethod):
         device: str = 'cpu',
         verbose: bool = False,
     ):
+        cv2 = import_cv2()
         super().__init__(device=device, verbose=verbose)
 
         self.sift = cv2.SIFT_create(
@@ -2251,6 +2288,7 @@ class SIFT(ImageRegistrationMethod):
         self,
         image: Union[np.ndarray, torch.Tensor],
     ):
+        cv2 = import_cv2()
         if isinstance(image, torch.Tensor):
             image = image.cpu().numpy()
         if image.ndim == 3:
@@ -2299,12 +2337,13 @@ class ORB(ImageRegistrationMethod):
         edgeThreshold: int = 31,
         firstLevel: int = 0,
         WTA_K: int = 2,
-        scoreType: int = cv2.ORB_HARRIS_SCORE,
+        scoreType: Optional[int] = None,  ## None -> cv2.ORB_HARRIS_SCORE (== 0)
         patchSize: int = 31,
         fastThreshold: int = 20,
         device: str = 'cpu',
         verbose: bool = False,
     ):
+        cv2 = import_cv2()
         super().__init__(device=device, verbose=verbose)
         self.orb = cv2.ORB_create(
             nfeatures=nfeatures,
@@ -2313,7 +2352,7 @@ class ORB(ImageRegistrationMethod):
             edgeThreshold=edgeThreshold,
             firstLevel=firstLevel,
             WTA_K=WTA_K,
-            scoreType=scoreType,
+            scoreType=cv2.ORB_HARRIS_SCORE if scoreType is None else scoreType,
             patchSize=patchSize,
             fastThreshold=fastThreshold,
         )
@@ -2347,6 +2386,7 @@ class ORB(ImageRegistrationMethod):
         self,
         image: Union[np.ndarray, torch.Tensor],
     ):
+        cv2 = import_cv2()
         if isinstance(image, torch.Tensor):
             image = image.cpu().numpy()
         if image.ndim == 3:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2931,3 +2931,121 @@ class Test_richfile_type_registry:
         dependency, so no type should claim to come from it."""
         offenders = [p['type_name'] for p in self._registered_properties() if p['library'] == 'onnx2torch']
         assert not offenders, f'types still attributed to onnx2torch: {offenders}'
+
+
+######################################################################################################################################
+######################################################## OPTIONAL OPENCV #############################################################
+######################################################################################################################################
+
+
+class Test_opencv_is_optional:
+    """
+    ``roicat/tracking/alignment.py`` imported cv2 at module scope, and
+    ``roicat/__init__.py`` imports the tracking subpackage, so ``import roicat``
+    required OpenCV. OpenCV ships only with the `tracking` extras, so a
+    ``roicat[classification]`` install could not import the package at all.
+    See issue #662. CI missed it because the matrix only builds `dev` /
+    `dev_latest`, which resolve to `all` and install everything.
+    """
+
+    def test_no_module_scope_cv2_import_in_roicat(self):
+        """cv2 may be imported inside a function, never at module scope --
+        module scope is what runs on `import roicat`."""
+        import ast
+        import roicat
+
+        root = Path(roicat.__file__).parent
+        offenders = []
+        for path in sorted(root.rglob('*.py')):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in tree.body:  ## module scope only
+                names = []
+                if isinstance(node, ast.Import):
+                    names = [a.name for a in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    names = [node.module or '']
+                if any(n == 'cv2' or n.startswith('cv2.') for n in names):
+                    offenders.append(f'{path.relative_to(root)}:{node.lineno}')
+        assert not offenders, (
+            f'cv2 imported at module scope (breaks `import roicat` without OpenCV): {offenders}'
+        )
+
+    def test_no_cv2_constant_in_a_default_argument(self):
+        """A `cv2.` constant used as a default argument is evaluated when the
+        module is imported, so it defeats a lazy import just as surely as a
+        module-scope `import cv2` does. Both `OpticalFlowFarneback.__init__`
+        and `ORB.__init__` used to do this."""
+        import ast
+
+        from roicat.tracking import alignment
+
+        tree = ast.parse(Path(alignment.__file__).read_text())
+
+        def uses_cv2(n):
+            return any(isinstance(x, ast.Name) and x.id == 'cv2' for x in ast.walk(n))
+
+        offenders = []
+
+        def scan(body, ctx=''):
+            for node in body:
+                if isinstance(node, ast.ClassDef):
+                    scan(node.body, f'{ctx}{node.name}.')
+                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    args = node.args
+                    defaults = list(args.defaults) + [d for d in args.kw_defaults if d]
+                    if any(uses_cv2(d) for d in defaults):
+                        offenders.append(f'{ctx}{node.name}() default arg')
+                elif uses_cv2(node):
+                    offenders.append(f'{ctx}statement at line {node.lineno}')
+
+        scan(tree.body)
+        assert not offenders, f'cv2 evaluated at import time: {offenders}'
+
+    def test_import_roicat_succeeds_without_opencv(self):
+        """The end-to-end check: a fresh interpreter that cannot import cv2
+        must still be able to import roicat."""
+        import subprocess
+        import sys
+        import textwrap
+
+        script = textwrap.dedent(
+            '''
+            import sys
+            from importlib.abc import MetaPathFinder
+
+            class _BlockCV2(MetaPathFinder):
+                """Make cv2 unimportable, as it is on a classification-only install."""
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname == 'cv2' or fullname.startswith('cv2.'):
+                        raise ImportError(f'blocked for test: {fullname}')
+                    return None
+
+            sys.meta_path.insert(0, _BlockCV2())
+            for name in list(sys.modules):
+                if name == 'cv2' or name.startswith('cv2.'):
+                    del sys.modules[name]
+
+            import roicat
+            import roicat.tracking.alignment
+            print('IMPORT_OK')
+            '''
+        )
+        result = subprocess.run(
+            [sys.executable, '-c', script],
+            capture_output=True, text=True, timeout=900,
+        )
+        assert 'IMPORT_OK' in result.stdout, (
+            f'importing roicat without OpenCV failed:\n'
+            f'--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}'
+        )
+
+    def test_error_names_what_to_install(self, monkeypatch):
+        """When an alignment routine is actually reached without OpenCV, the
+        error should say what to install rather than a bare ModuleNotFoundError."""
+        import sys
+
+        from roicat.tracking import alignment
+
+        monkeypatch.setitem(sys.modules, 'cv2', None)
+        with pytest.raises(ImportError, match='opencv'):
+            alignment.import_cv2()


### PR DESCRIPTION
Fixes #662.

## The problem

`roicat/tracking/alignment.py` imported `cv2` at module scope. `roicat/__init__.py` imports the tracking subpackage, so **`import roicat` required OpenCV**.

OpenCV ships only with the `tracking` extras, so `pip install roicat[classification]` produced a package that could not be imported at all — not "alignment doesn't work", but `import roicat` failing outright.

CI never saw it because the matrix only builds `dev` / `dev_latest`, which resolve to `all` and install everything.

## The fix

OpenCV is used only by the alignment routines, so it is now imported inside the eight functions that use it, through `alignment.import_cv2()` — the same shape as `scatteringWaveletTransformer.import_Scattering2D`. The failure stays local to the feature that needs it, and the error names what to install:

```
ImportError: OpenCV is required for ROICaT's image alignment, but is not installed.
Install it with `pip install roicat[tracking]`, or directly with
`pip install opencv-contrib-python-headless`.
```

**Two default arguments also had to change**, and they are why this is not a one-line fix. `OpticalFlowFarneback.__init__` took `flags=cv2.OPTFLOW_FARNEBACK_GAUSSIAN` and `ORB.__init__` took `scoreType=cv2.ORB_HARRIS_SCORE`. Default arguments are evaluated when the module is imported, so those defeated a lazy import just as surely as the module-scope `import cv2` did. Both are now `None` sentinels resolved in the function body, preserving the same values (256 and 0).

Verified directly: a fresh interpreter with `cv2` blocked via `sys.meta_path` now runs `import roicat` and `import roicat.tracking.alignment` successfully.

## Why lazy import rather than adding OpenCV to `core`

Both were on the table in #662 and either would fix the import. Lazy import wins on two points:

- OpenCV is already an unconditional dependency of `romatch-roicat`, so **every tracking install has it regardless** — a real tracking user cannot hit the new call-time error.
- Adding `opencv-contrib-python-headless` to `core` would force that specific variant on classification-only users who never touch alignment. Anyone who already has `opencv-python` then has two distributions providing the same `cv2` namespace, a known breakage source.

So classification users pay nothing, and tracking users see no behaviour change.

## Tests

- Static guard: nothing in `roicat/` imports cv2 at module scope.
- Static guard: no `cv2.` constant appears in a default argument — the subtler half of the same bug.
- End-to-end: a fresh interpreter with cv2 blocked can still `import roicat`. **This is the one that would have caught it.**
- The error names the package to install, rather than a bare `ModuleNotFoundError`.

Full local suite on this branch: 198 passed.
