### PR TITLE
fix(deps): move opencv into core, where `import roicat` needs it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ core = [
     "onnxruntime==1.28.0",
     "richfile>=0.6.2",
     "sparse_convolution>=0.4.0",
+    ## Imported at module scope by roicat/tracking/alignment.py, and
+    ## roicat/__init__.py imports the tracking subpackage, so `import roicat`
+    ## needs it regardless of which extra was installed.
+    "opencv-contrib-python-headless<=5.0.0.93",
 ]
 classification = [
     "roicat[core]",
@@ -64,7 +68,6 @@ classification = [
 ]
 tracking = [
     "roicat[core]",
-    "opencv-contrib-python-headless<=5.0.0.93",
     "fast-hdbscan==0.3.2",
     "kymatio==0.3.0",
     "kornia==0.8.3",
@@ -104,6 +107,7 @@ core_latest = [
     "onnxruntime",
     "richfile",
     "sparse_convolution",
+    "opencv-contrib-python-headless",
 ]
 classification_latest = [
     "roicat[core_latest]",
@@ -114,7 +118,6 @@ classification_latest = [
 ]
 tracking_latest = [
     "roicat[core_latest]",
-    "opencv-contrib-python-headless",
     "fast-hdbscan",
     "kymatio",
     "kornia",

--- a/tests/test_pyproject_extras.py
+++ b/tests/test_pyproject_extras.py
@@ -148,13 +148,18 @@ def test_import_time_dependencies_are_declared():
         'richfile': 'richfile',
     }
     extras = _load_extras()
-    declared = _resolve(extras, 'all')
+    ## Resolved against `core`, not `all`: `core` is the floor every other extra
+    ## builds on, so it is the only place a declaration guarantees the package is
+    ## present for *every* install. Checking `all` passed while `cv2` was declared
+    ## only in `tracking`, which left `roicat[classification]` unable to run
+    ## `import roicat` at all.
+    declared = _resolve(extras, 'core')
     missing = sorted({
         dist for dist in MODULES_IMPORT_TIME.values()
         if dist.replace('_', '-') not in declared
     })
     assert not missing, (
-        f'Imported at import time but not declared in the "all" extra: {missing}'
+        f'Imported at import time but not declared in the "core" extra: {missing}'
     )
 
 


### PR DESCRIPTION
Fixes #662.

## The problem

`roicat/tracking/alignment.py` imports `cv2` at module scope, and `roicat/__init__.py` eagerly imports the tracking subpackage. So **`import roicat` requires OpenCV no matter which extra you installed** — but OpenCV was declared only in `tracking` / `tracking_latest`.

A `pip install roicat[classification]` therefore produced a package that could not be imported at all.

## The fix

Declare it where the code needs it: `core`, the floor every other extra builds on. Moved rather than duplicated, since `tracking` already includes `core`.

| extra | opencv before | opencv after |
|---|---|---|
| `core` | no | **yes** |
| `classification` | no | **yes** |
| `tracking` | yes | yes |
| `all` | yes | yes |

## Why this rather than a lazy import

Lazy-importing `cv2` inside the nine functions in `alignment.py` that use it is the cleaner end state, and it is cheap — only 2 of the 24 `cv2.` references evaluate at import time (two integer default args, `OPTFLOW_FARNEBACK_GAUSSIAN` and `ORB_HARRIS_SCORE`).

But while `roicat/__init__.py` eagerly imports every submodule, *every* import-time dependency of `tracking` is a de-facto core dependency, so lazy-importing one package is whack-a-mole against the next module-scope import someone adds. Making `__init__.py` lazy is the real fix and deserves its own change.

Cost in context: 90 MB against a `core` that already installs torch (1.1 GB) and its CUDA libraries (2.7 GB).

## The test is the bug in miniature

`test_import_time_dependencies_are_declared` already listed `'cv2'` as an import-time dependency — and passed the whole time, because it resolved against **`all`**, which includes `tracking` and therefore picked up cv2. The extras a user might actually install were never checked.

Now it resolves against **`core`**. Verified it fails on `dev`, naming exactly `opencv-contrib-python-headless`.
