### PR TITLE
fix(release): attach dists and Sigstore bundles to the GitHub Release

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -102,6 +102,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: >-
         gh release create "v$VERSION" 
+        ./dist/* 
         --title "v$VERSION" 
         --notes "Release for version $VERSION. Also available on PyPI: https://pypi.org/project/roicat/$VERSION/"
         --repo ${{ github.repository }}


### PR DESCRIPTION
Workflow fix only. No version bump, nothing published.

`gh release create` in `.github/workflows/pypi_release.yml` was called with no
file arguments, so it created the GitHub Release and uploaded nothing. The
signing step does work — it writes `<artifact>.sigstore.json` next to each dist
— but those files existed only on the runner and were discarded when the job
ended.

That is why every release so far has zero assets: v1.7.5, v1.7.6, v1.7.7 and
v1.7.9 alike. The 1.7.8 failure made this look like a signing problem, but
signing was only half of it.

```diff
       run: >-
         gh release create "v$VERSION" 
+        ./dist/* 
         --title "v$VERSION" 
```

At that point `dist/` holds four files — the wheel, the sdist, and a Sigstore
bundle for each — so all four get attached and the signatures become available
to anyone verifying a download.

Verified the shape of the command rather than assuming it: `gh release create`
takes files positionally after the tag (`gh release create [<tag>] [<files>...]`),
and the folded YAML block expands to the four paths in the right position.

Takes effect on the next release. The 1.7.9 bundles are already gone and cannot
be recovered — regenerating them locally would sign with a personal identity
rather than the repository's, which would be worse than having none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)